### PR TITLE
fix: harden iri-input and agent-picker widgets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,7 @@ prez-lite/
 │   ├── data-processing/   # TTL → JSON pipeline (N3.js, SHACL profiles)
 │   ├── web-components/    # Lit-based embeddable components (prez-lite.min.js)
 │   ├── github-auth-worker/# Cloudflare Worker for GitHub OAuth (inline editing)
-│   ├── sites/             # Client site implementations
-│   │   └── suncorp-vpp/   # Suncorp VPP (extends web/ as Nuxt layer)
+│   ├── sites/             # Client site implementations (separate repos, gitignored)
 │   ├── gh-templates/      # GitHub template repositories
 │   │   └── default/       # Standard vocabulary template (subtree sync)
 │   └── examples/          # Example data and configurations
@@ -49,10 +48,10 @@ prez-lite/
 
 **Client sites** (`packages/sites/*`) and **template repos** (`packages/gh-templates/*`) are **separate git repositories** checked out within the prez-lite monorepo for convenience. They are **not part of the main prez-lite project**.
 
-- Each directory under `packages/sites/` (e.g., `suncorp-vpp`) has its own `.git` directory
-- Each directory under `packages/gh-templates/` (e.g., `default`) has its own `.git` directory
-- These are listed in `.gitignore` so changes don't affect the main repo
-- They have their own remotes (e.g., `Kurrawong/suncorp-vpp`, `Kurrawong/prez-lite-template-default`)
+- Each directory under `packages/sites/` has its own `.git` directory and remote
+- Each directory under `packages/gh-templates/` has its own `.git` directory and remote
+- These are listed in `.gitignore` so changes don't affect the main prez-lite repo
+- Always work with these repos in-place — never clone them elsewhere
 
 **Before cloning a child site or template:**
 1. Check if it already exists in `packages/sites/` or `packages/gh-templates/`
@@ -181,20 +180,19 @@ Client sites extend `web/` as a Nuxt layer, overriding components, content, and 
 - Caller workflows in `.github/workflows/` invoke prez-lite's reusable workflows
 - `public/export/` is gitignored — CI regenerates it
 
+Each site under `packages/sites/` is its own repo — commit and push directly from within the site directory.
+
 ## Template Repository (`packages/gh-templates/default/`)
 
 - **Not in pnpm workspace** — has its own `package.json` and `node_modules/`
-- Synced to `Kurrawong/prez-lite-template-default` via git subtree
+- Separate git repo cloned in-place (`Kurrawong/prez-lite-template-default`)
+- Commit and push directly from within the directory
 
 ```bash
 cd packages/gh-templates/default
 pnpm install        # independent install
 pnpm process        # regenerate vocab exports (auto-detects monorepo)
 pnpm dev            # start dev server
-
-# Subtree sync
-./scripts/sync-template-push.sh   # push to prez-lite-template-default
-./scripts/sync-template-pull.sh   # pull changes back (squashed)
 ```
 
 ## Important Principles
@@ -209,6 +207,16 @@ pnpm dev            # start dev server
 - PR titles must use **lowercase** conventional commit format: `type: description`
 - Valid types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
 - Do not include "Generated with Claude Code" in PRs, commits, comments, or issues
+
+## Widget Development Checklist
+
+When adding a new `EditableProperty['fieldType']` to `useEditMode.ts` (or a new render branch in `InlineEditTable.vue` / `ConceptForm.vue`):
+
+1. **Lifecycle check** — verify the full happy *and* edge path before commit: add → edit value → clear value → add a second value → remove → save → reload from GitHub. Walking only the "does it render" path misses the bugs that ship.
+2. **Validation parity** — add a matching rule in `validateSubject` the moment the new field type is introduced. e.g. an IRI-typed field must reject empty / non-IRI values; a date field must reject malformed dates. Validation rules and field types travel together.
+3. **Defensive serialisation** — `serializeWithPatch` and `serializeToTTL` must refuse to emit invalid quads (empty `NamedNode`s, malformed URIs, literals without required language tags). Audit these functions when introducing a new value-shape.
+4. **Unit tests in the same PR** — cover at minimum: (a) widget dispatch from a representative profile shape (`getPropertiesForSubject` picks the right `fieldType`), (b) full mutation cycle (`addValue` → `updateValue('')` → store state), and (c) the resulting TTL is valid (no empty-IRI quads, no broken literals).
+5. **Profile parser parity** — every new SHACL constraint the widget consumes (e.g. `sh:nodeKind`, `sh:hasValue`) must be extracted in `web/app/utils/shacl-profile-parser.ts` *and* emitted by `packages/data-processing/scripts/process-vocab.js`. Without both, the constraint silently disappears between `profiles.ttl` and the running app.
 
 ## Don't Forget
 

--- a/web/app/components/ConceptForm.vue
+++ b/web/app/components/ConceptForm.vue
@@ -29,6 +29,17 @@ const emit = defineEmits<{
 const SKOS_BROADER = 'http://www.w3.org/2004/02/skos/core#broader'
 const SKOS_RELATED = 'http://www.w3.org/2004/02/skos/core#related'
 
+/**
+ * True if this iri-input property already has an empty / placeholder value
+ * (#29). Used to hide "Add IRI" until the user finishes typing the
+ * incomplete one — otherwise the dedup'd addQuad makes the click silently
+ * fail.
+ */
+function hasIncompleteIriValue(prop: EditableProperty): boolean {
+  const bareSeeds = new Set(['https://', 'http://', 'urn:', ''])
+  return prop.values.some(v => bareSeeds.has((v.value ?? '').trim()))
+}
+
 // Reka UI SelectItem rejects empty-string values, so we use a sentinel
 // for "no language tag" and convert at the model-value boundary.
 const LANG_NONE = '_none'
@@ -237,8 +248,10 @@ function formatIri(iri: string): string {
               @click="emit('remove:value', prop.predicate, val)"
             />
           </div>
+          <!-- Hide "Add IRI" while an existing row is still a bare scheme seed
+               or empty (#29) — clicking would otherwise be a dedup no-op. -->
           <UButton
-            v-if="prop.maxCount == null || prop.values.length < prop.maxCount"
+            v-if="!hasIncompleteIriValue(prop) && (prop.maxCount == null || prop.values.length < prop.maxCount)"
             icon="i-heroicons-plus"
             variant="ghost"
             size="xs"

--- a/web/app/components/InlineEditTable.vue
+++ b/web/app/components/InlineEditTable.vue
@@ -126,6 +126,30 @@ function formatIriAuto(iri: string): string {
   return formatIri(iri)
 }
 
+/**
+ * Pick a default agent IRI for a new agent-picker row that isn't already
+ * one of this property's existing values. Without this, N3.Store dedupes
+ * the addQuad and the "Add agent" click appears to do nothing (#28).
+ * Returns null if every loaded agent is already in use.
+ */
+function nextUnusedAgentIri(prop: EditableProperty | EditableNestedProperty): string | null {
+  if (!props.agents?.length) return null
+  const used = new Set(prop.values.map(v => v.value))
+  const unused = props.agents.find(a => !used.has(a.iri))
+  return unused?.iri ?? null
+}
+
+/**
+ * True if this iri-input property already has an empty / placeholder value
+ * (#29). Used to hide "Add IRI" until the user finishes typing the
+ * incomplete one — otherwise the dedup'd addQuad makes the click silently
+ * fail.
+ */
+function hasIncompleteIriValue(prop: EditableProperty | EditableNestedProperty): boolean {
+  const bareSeeds = new Set(['https://', 'http://', 'urn:', ''])
+  return prop.values.some(v => bareSeeds.has((v.value ?? '').trim()))
+}
+
 function constraintDescription(prop: EditableProperty): string | null {
   const parts: string[] = []
   if (prop.minCount != null) parts.push(`Min: ${prop.minCount}`)
@@ -486,8 +510,11 @@ onUnmounted(() => {
                         @click.stop="emit('remove:value', prop.predicate, val)"
                       />
                     </div>
+                    <!-- Hide "Add IRI" while an existing row is still a bare scheme seed
+                         or empty (#29) — clicking would otherwise be a dedup no-op AND
+                         leave the existing invalid value un-edited. -->
                     <UButton
-                      v-if="prop.maxCount == null || prop.values.length < prop.maxCount"
+                      v-if="!hasIncompleteIriValue(prop) && (prop.maxCount == null || prop.values.length < prop.maxCount)"
                       icon="i-heroicons-plus"
                       variant="ghost"
                       size="xs"
@@ -520,11 +547,11 @@ onUnmounted(() => {
                       />
                     </div>
                     <UButton
-                      v-if="agents?.length && (prop.maxCount == null || prop.values.length < prop.maxCount)"
+                      v-if="nextUnusedAgentIri(prop) && (prop.maxCount == null || prop.values.length < prop.maxCount)"
                       icon="i-heroicons-plus"
                       variant="ghost"
                       size="xs"
-                      @click.stop="emit('add:value', prop.predicate, 'iri', agents![0].iri)"
+                      @click.stop="emit('add:value', prop.predicate, 'iri', nextUnusedAgentIri(prop)!)"
                     >
                       Add agent
                     </UButton>

--- a/web/app/composables/useEditMode.ts
+++ b/web/app/composables/useEditMode.ts
@@ -10,6 +10,7 @@
 
 import { Store, Parser, Writer, DataFactory, type Quad } from 'n3'
 import { getPredicateLabel, getPredicateDescription } from '~/utils/vocab-labels'
+import { isIriValued, isValidIri, pruneInvalidIriQuads } from '~/utils/iri-validation'
 import {
   extractPrefixes,
   parseSubjectBlocks,
@@ -145,34 +146,8 @@ const SDO = 'https://schema.org/'
 
 const SKOS_CONCEPT_CLASS = `${SKOS}Concept`
 const PROV_AGENT_CLASS = 'http://www.w3.org/ns/prov#Agent'
-const SH_IRI = 'http://www.w3.org/ns/shacl#IRI'
-
-/** True if the property shape declares its value must be an IRI */
-function isIriValued(po: { class?: string; nodeKind?: string }): boolean {
-  if (po.nodeKind === SH_IRI) return true
-  // Any sh:class constraint implies the value is a typed IRI (instance of that class)
-  if (po.class) return true
-  return false
-}
-
-/**
- * Loose IRI validity check used for save-time validation and defensive
- * serialisation. We accept anything that looks like `scheme:opaque-part`
- * (where opaque-part has no whitespace and is non-empty after the colon).
- *
- * Bare scheme prefixes that the iri-input widget seeds (`https://`,
- * `http://`, `urn:`) are rejected as "incomplete" — the user must finish
- * typing the IRI before save.
- */
-const BARE_SCHEME_SEEDS = new Set(['https://', 'http://', 'urn:'])
-function isValidIri(value: string | undefined | null): boolean {
-  if (!value) return false
-  const v = value.trim()
-  if (!v) return false
-  if (BARE_SCHEME_SEEDS.has(v)) return false
-  // Require a scheme followed by something non-empty and whitespace-free.
-  return /^[a-zA-Z][a-zA-Z0-9+.\-]*:[^\s]+$/.test(v)
-}
+// isIriValued / isValidIri / pruneInvalidIriQuads live in ~/utils/iri-validation
+// so the validation logic can be unit-tested without a Nuxt context.
 
 const TEXTAREA_PREDICATES = new Set([
   `${SKOS}definition`,
@@ -981,41 +956,19 @@ export function useEditMode(
   // ---- Serialization ----
 
   /**
-   * Defensive: refuse to emit quads with empty or otherwise invalid IRI
-   * objects (issue #29). Validation should catch these and block the save,
-   * but if a value sneaks through (e.g. the user typed and cleared right
-   * before clicking save) we silently drop it rather than producing
-   * broken TTL like `<s> <p> <> .`.
-   *
-   * Catches both:
-   *   - NamedNode terms with values failing isValidIri
-   *   - Any object term with empty `value` (N3's DataFactory turns
-   *     namedNode('') into a DefaultGraph-typed term with empty value,
-   *     which the Turtle writer emits as `<>`)
-   *
-   * Returns the number of dropped quads so callers can log if it happens.
+   * Defensive backstop before any TTL output (issue #29). Validation should
+   * already have blocked the save, but if a value sneaks through (e.g. the
+   * user typed and cleared right before clicking save) we silently drop it
+   * rather than producing broken TTL like `<s> <p> <> .`.
+   * See `~/utils/iri-validation` for the rules.
    */
   function pruneInvalidQuads(): number {
     if (!store.value) return 0
-    const invalid = (store.value.getQuads(null, null, null, null) as Quad[])
-      .filter(q => {
-        const obj = q.object
-        // Empty value on anything non-literal is broken (N3 normalises
-        // namedNode('') to DefaultGraph-typed, so this catches that path)
-        if (obj.termType !== 'Literal' && obj.termType !== 'BlankNode' && !obj.value) {
-          return true
-        }
-        // NamedNode that doesn't look like an IRI
-        if (obj.termType === 'NamedNode' && !isValidIri(obj.value)) {
-          return true
-        }
-        return false
-      })
-    if (invalid.length) {
-      store.value.removeQuads(invalid)
-      console.warn('[useEditMode] Pruned', invalid.length, 'quads with invalid IRI objects before serialise.')
+    const dropped = pruneInvalidIriQuads(store.value)
+    if (dropped) {
+      console.warn('[useEditMode] Pruned', dropped, 'quads with invalid IRI objects before serialise.')
     }
-    return invalid.length
+    return dropped
   }
 
   function serializeToTTL(): string {

--- a/web/app/composables/useEditMode.ts
+++ b/web/app/composables/useEditMode.ts
@@ -155,6 +155,25 @@ function isIriValued(po: { class?: string; nodeKind?: string }): boolean {
   return false
 }
 
+/**
+ * Loose IRI validity check used for save-time validation and defensive
+ * serialisation. We accept anything that looks like `scheme:opaque-part`
+ * (where opaque-part has no whitespace and is non-empty after the colon).
+ *
+ * Bare scheme prefixes that the iri-input widget seeds (`https://`,
+ * `http://`, `urn:`) are rejected as "incomplete" — the user must finish
+ * typing the IRI before save.
+ */
+const BARE_SCHEME_SEEDS = new Set(['https://', 'http://', 'urn:'])
+function isValidIri(value: string | undefined | null): boolean {
+  if (!value) return false
+  const v = value.trim()
+  if (!v) return false
+  if (BARE_SCHEME_SEEDS.has(v)) return false
+  // Require a scheme followed by something non-empty and whitespace-free.
+  return /^[a-zA-Z][a-zA-Z0-9+.\-]*:[^\s]+$/.test(v)
+}
+
 const TEXTAREA_PREDICATES = new Set([
   `${SKOS}definition`,
   `${SKOS}scopeNote`,
@@ -615,7 +634,11 @@ export function useEditMode(
             : literal(oldValue.value)
       store.value.removeQuad(s, p, oldObj, defaultGraph())
 
-      // Add new quad
+      // Add new quad. For IRI values we still add a (placeholder) quad so
+      // the UI keeps showing the row the user is editing — validation
+      // surfaces the invalid IRI and `pruneInvalidQuads` will strip it
+      // before serialisation. Without the placeholder the row disappears
+      // when the user clears the input.
       const newObj = oldValue.type === 'iri'
         ? namedNode(newValue)
         : oldValue.language
@@ -957,8 +980,47 @@ export function useEditMode(
 
   // ---- Serialization ----
 
+  /**
+   * Defensive: refuse to emit quads with empty or otherwise invalid IRI
+   * objects (issue #29). Validation should catch these and block the save,
+   * but if a value sneaks through (e.g. the user typed and cleared right
+   * before clicking save) we silently drop it rather than producing
+   * broken TTL like `<s> <p> <> .`.
+   *
+   * Catches both:
+   *   - NamedNode terms with values failing isValidIri
+   *   - Any object term with empty `value` (N3's DataFactory turns
+   *     namedNode('') into a DefaultGraph-typed term with empty value,
+   *     which the Turtle writer emits as `<>`)
+   *
+   * Returns the number of dropped quads so callers can log if it happens.
+   */
+  function pruneInvalidQuads(): number {
+    if (!store.value) return 0
+    const invalid = (store.value.getQuads(null, null, null, null) as Quad[])
+      .filter(q => {
+        const obj = q.object
+        // Empty value on anything non-literal is broken (N3 normalises
+        // namedNode('') to DefaultGraph-typed, so this catches that path)
+        if (obj.termType !== 'Literal' && obj.termType !== 'BlankNode' && !obj.value) {
+          return true
+        }
+        // NamedNode that doesn't look like an IRI
+        if (obj.termType === 'NamedNode' && !isValidIri(obj.value)) {
+          return true
+        }
+        return false
+      })
+    if (invalid.length) {
+      store.value.removeQuads(invalid)
+      console.warn('[useEditMode] Pruned', invalid.length, 'quads with invalid IRI objects before serialise.')
+    }
+    return invalid.length
+  }
+
   function serializeToTTL(): string {
     if (!store.value) return ''
+    pruneInvalidQuads()
 
     const writer = new Writer({
       prefixes: originalPrefixes.value,
@@ -986,6 +1048,7 @@ export function useEditMode(
         'originalParsedTTL:', !!originalParsedTTL.value)
       return serializeToTTL()
     }
+    pruneInvalidQuads()
 
     if (originalParsedTTL.value.subjectBlocks.length === 0) {
       console.warn('[useEditMode] originalParsedTTL has 0 subject blocks — patching will append instead of replace.')
@@ -1319,6 +1382,30 @@ export function useEditMode(
         }
       }
 
+      // Check that IRI-typed values look like real IRIs (issue #29).
+      // Catches blank values and bare scheme seeds like "https://" that the
+      // iri-input widget defaults to. Without this, a save would produce
+      // an empty NamedNode (or DefaultGraph term, since N3 collapses
+      // namedNode('') to that) and broken TTL output.
+      if (isIriValued(po)) {
+        for (const q of quads) {
+          const obj = q.object
+          // Skip literals and blank nodes — they're a separate concern.
+          if (obj.termType === 'Literal' || obj.termType === 'BlankNode') continue
+          if (!isValidIri(obj.value)) {
+            errors.push({
+              subjectIri,
+              subjectLabel,
+              predicate: po.path,
+              predicateLabel: getPredicateLabel(po.path),
+              message: obj.value
+                ? `"${obj.value}" is not a valid IRI`
+                : 'IRI value cannot be empty',
+            })
+          }
+        }
+      }
+
       // Validate nested properties
       if (po.propertyOrder) {
         const parentLabel = getPredicateLabel(po.path)
@@ -1357,6 +1444,24 @@ export function useEditMode(
                     predicate: po.path,
                     predicateLabel: parentLabel,
                     message: `${nestedLabel} "${nq.object.value}" is not an allowed value`,
+                  })
+                }
+              }
+            }
+            // Check IRI validity on nested properties (issue #29)
+            if (isIriValued(nested)) {
+              for (const nq of nestedQuads) {
+                const obj = nq.object
+                if (obj.termType === 'Literal' || obj.termType === 'BlankNode') continue
+                if (!isValidIri(obj.value)) {
+                  errors.push({
+                    subjectIri,
+                    subjectLabel,
+                    predicate: po.path,
+                    predicateLabel: parentLabel,
+                    message: obj.value
+                      ? `${nestedLabel} "${obj.value}" is not a valid IRI`
+                      : `${nestedLabel} IRI value cannot be empty`,
                   })
                 }
               }

--- a/web/app/utils/iri-validation.ts
+++ b/web/app/utils/iri-validation.ts
@@ -1,0 +1,79 @@
+/**
+ * IRI validation helpers used by the editor's widget dispatch, save-time
+ * validation, and defensive serialisation passes.
+ *
+ * Kept as a leaf utility (no Vue / Nuxt imports) so it can be tested
+ * directly without a Nuxt environment.
+ */
+
+import { Store, type Quad } from 'n3'
+
+/** SHACL constant for IRI-only node values */
+export const SH_IRI = 'http://www.w3.org/ns/shacl#IRI'
+
+/**
+ * Bare scheme prefixes the iri-input widget seeds new values with. Treated
+ * as "not yet finished typing" — neither saved nor serialised.
+ */
+const BARE_SCHEME_SEEDS = new Set(['https://', 'http://', 'urn:'])
+
+/** Subset of `ProfilePropertyOrder` this module needs to read */
+export interface IriShapeHints {
+  class?: string
+  nodeKind?: string
+}
+
+/**
+ * True if the property shape declares its value must be an IRI.
+ * `sh:nodeKind sh:IRI` or any `sh:class` (which implies a typed IRI value).
+ */
+export function isIriValued(po: IriShapeHints): boolean {
+  if (po.nodeKind === SH_IRI) return true
+  if (po.class) return true
+  return false
+}
+
+/**
+ * Loose IRI validity check used for save-time validation and defensive
+ * serialisation. Accepts anything that looks like `scheme:opaque-part`
+ * (where opaque-part has no whitespace and is non-empty after the colon).
+ *
+ * Bare scheme prefixes that the iri-input widget seeds (`https://`,
+ * `http://`, `urn:`) are rejected as "incomplete" — the user must finish
+ * typing the IRI before save.
+ */
+export function isValidIri(value: string | undefined | null): boolean {
+  if (!value) return false
+  const v = value.trim()
+  if (!v) return false
+  if (BARE_SCHEME_SEEDS.has(v)) return false
+  return /^[a-zA-Z][a-zA-Z0-9+.\-]*:[^\s]+$/.test(v)
+}
+
+/**
+ * Defensive: remove any quad whose object is an empty / non-IRI NamedNode
+ * (or N3's DefaultGraph-typed placeholder for `namedNode('')`). Used right
+ * before serialising to TTL so we never emit broken `<>` syntax for
+ * incomplete iri-input values (#29).
+ *
+ * Mutates the passed store. Returns the number of quads removed.
+ */
+export function pruneInvalidIriQuads(store: Store): number {
+  const invalid = (store.getQuads(null, null, null, null) as Quad[]).filter(q => {
+    const obj = q.object
+    // Empty value on anything non-literal/non-blank is broken (N3 normalises
+    // namedNode('') to a DefaultGraph-typed term with empty value).
+    if (obj.termType !== 'Literal' && obj.termType !== 'BlankNode' && !obj.value) {
+      return true
+    }
+    // NamedNode whose value doesn't look like an IRI
+    if (obj.termType === 'NamedNode' && !isValidIri(obj.value)) {
+      return true
+    }
+    return false
+  })
+  if (invalid.length) {
+    store.removeQuads(invalid)
+  }
+  return invalid.length
+}

--- a/web/tests/unit/edit-validation.test.ts
+++ b/web/tests/unit/edit-validation.test.ts
@@ -27,6 +27,27 @@ interface ProfilePropertyOrder {
   minCount?: number
   maxCount?: number
   allowedValues?: string[]
+  class?: string
+  nodeKind?: string
+}
+
+const SH_IRI = 'http://www.w3.org/ns/shacl#IRI'
+const BARE_SCHEME_SEEDS = new Set(['https://', 'http://', 'urn:'])
+
+/** Mirrors isIriValued in useEditMode */
+function isIriValued(po: { class?: string; nodeKind?: string }): boolean {
+  if (po.nodeKind === SH_IRI) return true
+  if (po.class) return true
+  return false
+}
+
+/** Mirrors isValidIri in useEditMode */
+function isValidIri(value: string | undefined | null): boolean {
+  if (!value) return false
+  const v = value.trim()
+  if (!v) return false
+  if (BARE_SCHEME_SEEDS.has(v)) return false
+  return /^[a-zA-Z][a-zA-Z0-9+.\-]*:[^\s]+$/.test(v)
 }
 
 interface ValidationError {
@@ -83,6 +104,27 @@ function validateSubject(
             predicate: po.path,
             predicateLabel: getPredicateLabel(po.path),
             message: `"${q.object.value}" is not an allowed value`,
+          })
+        }
+      }
+    }
+
+    // Check IRI validity (issue #29) — catches empty NamedNodes and bare scheme seeds.
+    // N3's namedNode('') normalises to a DefaultGraph-typed term, so we check
+    // anything non-literal / non-blank rather than just NamedNode.
+    if (isIriValued(po)) {
+      for (const q of quads) {
+        const obj = q.object
+        if (obj.termType === 'Literal' || obj.termType === 'BlankNode') continue
+        if (!isValidIri(obj.value)) {
+          errors.push({
+            subjectIri,
+            subjectLabel,
+            predicate: po.path,
+            predicateLabel: getPredicateLabel(po.path),
+            message: obj.value
+              ? `"${obj.value}" is not a valid IRI`
+              : 'IRI value cannot be empty',
           })
         }
       }
@@ -349,6 +391,144 @@ describe('edit validation', () => {
       const store = new Store()
       const errors = validateSubject(store, CONCEPT_IRI, profile)
       expect(errors[0].subjectLabel).toBe('a')
+    })
+  })
+
+  /**
+   * IRI value validation — issue #29. The iri-input widget seeds new values
+   * with `https://`, so users can produce empty / scheme-only IRIs if they
+   * clear the seeded text. Validation must catch these before save.
+   */
+  describe('IRI validity (issue #29)', () => {
+    const iriPathProfile: ProfilePropertyOrder[] = [
+      { path: `${SDO}image`, order: 0, nodeKind: SH_IRI },
+      { path: `${SDO}creator`, order: 1, class: `${PROV}Agent` },
+    ]
+
+    it('accepts well-formed IRIs', () => {
+      const store = new Store()
+      store.addQuad(namedNode(CONCEPT_IRI), namedNode(`${SDO}image`), namedNode('https://example.com/img.png'), defaultGraph())
+      store.addQuad(namedNode(CONCEPT_IRI), namedNode(`${SDO}creator`), namedNode('https://linked.data.gov.au/org/ga'), defaultGraph())
+      const errors = validateSubject(store, CONCEPT_IRI, iriPathProfile)
+      expect(errors).toHaveLength(0)
+    })
+
+    it('rejects empty IRI (NamedNode with empty value)', () => {
+      const store = new Store()
+      store.addQuad(namedNode(CONCEPT_IRI), namedNode(`${SDO}image`), namedNode(''), defaultGraph())
+      const errors = validateSubject(store, CONCEPT_IRI, iriPathProfile)
+      expect(errors).toHaveLength(1)
+      expect(errors[0].message).toContain('cannot be empty')
+    })
+
+    it('rejects bare scheme seeds (the iri-input default before user edits)', () => {
+      for (const seed of ['https://', 'http://', 'urn:']) {
+        const store = new Store()
+        store.addQuad(namedNode(CONCEPT_IRI), namedNode(`${SDO}image`), namedNode(seed), defaultGraph())
+        const errors = validateSubject(store, CONCEPT_IRI, iriPathProfile)
+        expect(errors, `seed: ${seed}`).toHaveLength(1)
+        expect(errors[0].message).toContain('not a valid IRI')
+      }
+    })
+
+    it('rejects whitespace-only IRI', () => {
+      const store = new Store()
+      store.addQuad(namedNode(CONCEPT_IRI), namedNode(`${SDO}image`), namedNode('   '), defaultGraph())
+      const errors = validateSubject(store, CONCEPT_IRI, iriPathProfile)
+      expect(errors.length).toBeGreaterThan(0)
+    })
+
+    it('rejects malformed IRI (no scheme)', () => {
+      const store = new Store()
+      store.addQuad(namedNode(CONCEPT_IRI), namedNode(`${SDO}image`), namedNode('not-an-iri'), defaultGraph())
+      const errors = validateSubject(store, CONCEPT_IRI, iriPathProfile)
+      expect(errors).toHaveLength(1)
+    })
+
+    it('only applies to IRI-valued shapes; literals on non-IRI predicates pass', () => {
+      const profile: ProfilePropertyOrder[] = [
+        { path: `${SKOS}prefLabel`, order: 0 }, // no nodeKind/class → literal expected
+      ]
+      const store = new Store()
+      store.addQuad(namedNode(CONCEPT_IRI), namedNode(`${SKOS}prefLabel`), literal('Some label', 'en'), defaultGraph())
+      const errors = validateSubject(store, CONCEPT_IRI, profile)
+      expect(errors).toHaveLength(0)
+    })
+  })
+
+  /**
+   * Pure-function unit tests for the widget helpers added in InlineEditTable.vue
+   * (#28 "Add agent" dedup, #29 "Add IRI" with incomplete value).
+   */
+  describe('widget helpers', () => {
+    type AgentEntry = { iri: string; name: string; type: 'Person' | 'Organization' }
+    type PropLike = { values: Array<{ value: string }> }
+
+    function nextUnusedAgentIri(prop: PropLike, agents: AgentEntry[]): string | null {
+      if (!agents.length) return null
+      const used = new Set(prop.values.map(v => v.value))
+      return agents.find(a => !used.has(a.iri))?.iri ?? null
+    }
+
+    function hasIncompleteIriValue(prop: PropLike): boolean {
+      const bareSeeds = new Set(['https://', 'http://', 'urn:', ''])
+      return prop.values.some(v => bareSeeds.has((v.value ?? '').trim()))
+    }
+
+    const agents: AgentEntry[] = [
+      { iri: 'https://example.com/agent/ga', name: 'GA', type: 'Organization' },
+      { iri: 'https://example.com/agent/dpi', name: 'DPI', type: 'Organization' },
+      { iri: 'https://example.com/agent/csiro', name: 'CSIRO', type: 'Organization' },
+    ]
+
+    describe('nextUnusedAgentIri (#28 dedup fix)', () => {
+      it('returns the first agent when no values are set', () => {
+        const r = nextUnusedAgentIri({ values: [] }, agents)
+        expect(r).toBe(agents[0].iri)
+      })
+
+      it('skips agents already used as values', () => {
+        const r = nextUnusedAgentIri({ values: [{ value: agents[0].iri }] }, agents)
+        expect(r).toBe(agents[1].iri)
+      })
+
+      it('returns null when all agents are already used (blocks dedup no-op)', () => {
+        const r = nextUnusedAgentIri(
+          { values: agents.map(a => ({ value: a.iri })) },
+          agents,
+        )
+        expect(r).toBeNull()
+      })
+
+      it('returns null when the agents list is empty', () => {
+        const r = nextUnusedAgentIri({ values: [] }, [])
+        expect(r).toBeNull()
+      })
+    })
+
+    describe('hasIncompleteIriValue (#29 dedup fix)', () => {
+      it('false when all values are valid IRIs', () => {
+        expect(hasIncompleteIriValue({ values: [{ value: 'https://example.com/a' }] })).toBe(false)
+      })
+
+      it('true when any value is a bare scheme seed', () => {
+        for (const seed of ['https://', 'http://', 'urn:', '']) {
+          expect(
+            hasIncompleteIriValue({ values: [{ value: seed }] }),
+            `seed: ${JSON.stringify(seed)}`,
+          ).toBe(true)
+        }
+      })
+
+      it('true even when some values are valid (any incomplete blocks add)', () => {
+        expect(hasIncompleteIriValue({
+          values: [{ value: 'https://example.com/a' }, { value: 'https://' }],
+        })).toBe(true)
+      })
+
+      it('trims whitespace before checking', () => {
+        expect(hasIncompleteIriValue({ values: [{ value: '  https://  ' }] })).toBe(true)
+      })
     })
   })
 })

--- a/web/tests/unit/iri-validation.test.ts
+++ b/web/tests/unit/iri-validation.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests the production IRI validation helpers used by useEditMode for
+ * widget dispatch, save-time validation and defensive serialisation.
+ *
+ * Unlike the older edit-validation.test.ts (which mirrors validateSubject
+ * logic in the test file), these tests import the actual production code
+ * — so they will fail if the source diverges from intent.
+ */
+import { describe, it, expect } from 'vitest'
+import { Store, DataFactory } from 'n3'
+import {
+  isIriValued,
+  isValidIri,
+  pruneInvalidIriQuads,
+  SH_IRI,
+} from '~/utils/iri-validation'
+
+const { namedNode, literal, defaultGraph } = DataFactory
+
+const SDO = 'https://schema.org/'
+const OWL = 'http://www.w3.org/2002/07/owl#'
+const PROV = 'http://www.w3.org/ns/prov#'
+const SKOS = 'http://www.w3.org/2004/02/skos/core#'
+
+const SUBJECT = 'http://example.com/vocab'
+const PRED = `${OWL}versionIRI`
+
+// ============================================================================
+// isIriValued
+// ============================================================================
+
+describe('isIriValued', () => {
+  it('true when sh:nodeKind is sh:IRI', () => {
+    expect(isIriValued({ nodeKind: SH_IRI })).toBe(true)
+  })
+
+  it('true when sh:class is set (typed IRI value)', () => {
+    expect(isIriValued({ class: `${PROV}Agent` })).toBe(true)
+    expect(isIriValued({ class: `${SKOS}Concept` })).toBe(true)
+  })
+
+  it('false when neither hint is set', () => {
+    expect(isIriValued({})).toBe(false)
+  })
+
+  it('false for unrelated nodeKind values', () => {
+    expect(isIriValued({ nodeKind: 'http://www.w3.org/ns/shacl#Literal' })).toBe(false)
+  })
+})
+
+// ============================================================================
+// isValidIri
+// ============================================================================
+
+describe('isValidIri', () => {
+  describe('accepts', () => {
+    it.each([
+      ['https://example.com/'],
+      ['https://example.com/path/to/thing'],
+      ['http://example.com'],
+      ['urn:isbn:0451450523'],
+      ['urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6'],
+      ['https://linked.data.gov.au/org/ga'],
+      ['mailto:someone@example.com'],
+      ['ftp://files.example.com/x'],
+    ])('%s', (iri) => {
+      expect(isValidIri(iri)).toBe(true)
+    })
+  })
+
+  describe('rejects', () => {
+    it.each([
+      ['', 'empty string'],
+      ['   ', 'whitespace only'],
+      ['https://', 'bare https scheme seed'],
+      ['http://', 'bare http scheme seed'],
+      ['urn:', 'bare urn scheme seed'],
+      ['not-an-iri', 'no scheme'],
+      ['just text with no colon', 'no scheme'],
+      ['1http://x.com', 'scheme starting with digit'],
+      ['http //x.com', 'space in scheme'],
+      ['https://example .com', 'whitespace in path'],
+    ])('%s (%s)', (iri) => {
+      expect(isValidIri(iri)).toBe(false)
+    })
+
+    it('null', () => expect(isValidIri(null)).toBe(false))
+    it('undefined', () => expect(isValidIri(undefined)).toBe(false))
+  })
+
+  it('trims before checking — whitespace-padded valid IRI is accepted', () => {
+    expect(isValidIri('  https://example.com/  ')).toBe(true)
+  })
+
+  it('trims before checking — whitespace-padded bare seed is still rejected', () => {
+    expect(isValidIri('  https://  ')).toBe(false)
+  })
+})
+
+// ============================================================================
+// pruneInvalidIriQuads — direct exercise against a real N3.Store
+// ============================================================================
+
+describe('pruneInvalidIriQuads', () => {
+  function makeStore(): Store {
+    return new Store()
+  }
+
+  it('strips a quad whose object is the DefaultGraph-typed empty term (from namedNode(""))', () => {
+    const s = makeStore()
+    // This is what useEditMode.updateValue produces when the user clears
+    // an iri-input field — N3 turns namedNode('') into a DefaultGraph-typed term.
+    s.addQuad(namedNode(SUBJECT), namedNode(PRED), namedNode(''), defaultGraph())
+    expect(s.size).toBe(1)
+
+    const dropped = pruneInvalidIriQuads(s)
+
+    expect(dropped).toBe(1)
+    expect(s.size).toBe(0)
+  })
+
+  it('strips bare scheme seeds (incomplete iri-input values)', () => {
+    const s = makeStore()
+    s.addQuad(namedNode(SUBJECT), namedNode(PRED), namedNode('https://'), defaultGraph())
+    s.addQuad(namedNode(SUBJECT), namedNode(PRED), namedNode('urn:'), defaultGraph())
+    expect(s.size).toBe(2)
+
+    const dropped = pruneInvalidIriQuads(s)
+
+    expect(dropped).toBe(2)
+    expect(s.size).toBe(0)
+  })
+
+  it('strips malformed IRIs but keeps the valid ones in the same store', () => {
+    const s = makeStore()
+    s.addQuad(namedNode(SUBJECT), namedNode(PRED), namedNode('https://example.com/v1'), defaultGraph())
+    s.addQuad(namedNode(SUBJECT), namedNode(PRED), namedNode('not-an-iri'), defaultGraph())
+    s.addQuad(namedNode(SUBJECT), namedNode(PRED), namedNode(''), defaultGraph())
+
+    const dropped = pruneInvalidIriQuads(s)
+
+    expect(dropped).toBe(2)
+    expect(s.size).toBe(1)
+    const survivors = s.getQuads(null, null, null, null)
+    expect(survivors[0]!.object.value).toBe('https://example.com/v1')
+  })
+
+  it('preserves literal objects even when their value is empty (literals are a separate concern)', () => {
+    const s = makeStore()
+    s.addQuad(namedNode(SUBJECT), namedNode(`${SKOS}prefLabel`), literal('', 'en'), defaultGraph())
+    s.addQuad(namedNode(SUBJECT), namedNode(`${SKOS}prefLabel`), literal('Concept'), defaultGraph())
+
+    const dropped = pruneInvalidIriQuads(s)
+
+    expect(dropped).toBe(0)
+    expect(s.size).toBe(2)
+  })
+
+  it('preserves blank-node objects', () => {
+    const s = makeStore()
+    const { blankNode } = DataFactory
+    s.addQuad(namedNode(SUBJECT), namedNode(`${PROV}qualifiedAttribution`), blankNode('b1'), defaultGraph())
+
+    const dropped = pruneInvalidIriQuads(s)
+
+    expect(dropped).toBe(0)
+    expect(s.size).toBe(1)
+  })
+
+  it('returns 0 and no-ops when the store has no invalid quads', () => {
+    const s = makeStore()
+    s.addQuad(namedNode(SUBJECT), namedNode(`${SDO}creator`), namedNode('https://linked.data.gov.au/org/ga'), defaultGraph())
+
+    const dropped = pruneInvalidIriQuads(s)
+
+    expect(dropped).toBe(0)
+    expect(s.size).toBe(1)
+  })
+})
+
+// ============================================================================
+// Regression scenarios — these mimic the full bug paths from #29 end-to-end
+// using only the actual production primitives that drive serialisation.
+// ============================================================================
+
+describe('regression scenarios (issue #29)', () => {
+  /**
+   * Reproduces the broken-TTL symptom Nick reported: an iri-input row was
+   * cleared between addValue and save, and `<>` ended up in the serialised
+   * output. With pruneInvalidIriQuads run before serialise, the quad is
+   * gone and the writer emits clean TTL.
+   */
+  it('cleared iri-input value never reaches the Turtle writer', async () => {
+    const { Writer } = await import('n3')
+
+    const store = new Store()
+    // Simulate useEditMode's flow:
+    //   addValue('iri', 'https://') → store has https:// seed
+    store.addQuad(namedNode(SUBJECT), namedNode(PRED), namedNode('https://'), defaultGraph())
+    //   updateValue('') → store now has namedNode('') (DefaultGraph-typed)
+    store.removeQuad(namedNode(SUBJECT), namedNode(PRED), namedNode('https://'), defaultGraph())
+    store.addQuad(namedNode(SUBJECT), namedNode(PRED), namedNode(''), defaultGraph())
+
+    // Before prune: writer would emit `<>`
+    pruneInvalidIriQuads(store)
+
+    const writer = new Writer({ prefixes: { owl: OWL } })
+    for (const q of store.getQuads(null, null, null, null)) writer.addQuad(q)
+    let ttl = ''
+    writer.end((_err, result) => { ttl = result })
+
+    expect(ttl).not.toMatch(/<>/)
+    // The predicate IRI lookup is shorthand `owl:versionIRI` but the empty
+    // value would have produced `<>`. Absence of that token proves the fix.
+    expect(ttl).not.toMatch(/versionIRI\s*[;.]/)
+  })
+})

--- a/web/tests/unit/serialize-with-patch.test.ts
+++ b/web/tests/unit/serialize-with-patch.test.ts
@@ -392,4 +392,79 @@ describe('serializeWithPatch', () => {
       expect(result).toContain('Modified A')
     })
   })
+
+  /**
+   * Defensive pruning before serialise (issue #29). Mirrors the
+   * pruneInvalidQuads helper in useEditMode — quads whose object is an
+   * empty / non-IRI NamedNode (or N3's DefaultGraph-typed empty term)
+   * must be stripped before output to avoid emitting broken `<>` syntax.
+   */
+  describe('pruneInvalidQuads (#29)', () => {
+    const BARE_SCHEME_SEEDS = new Set(['https://', 'http://', 'urn:'])
+    function isValidIri(value: string | undefined | null): boolean {
+      if (!value) return false
+      const v = value.trim()
+      if (!v) return false
+      if (BARE_SCHEME_SEEDS.has(v)) return false
+      return /^[a-zA-Z][a-zA-Z0-9+.\-]*:[^\s]+$/.test(v)
+    }
+    function pruneInvalidQuads(store: Store): number {
+      const invalid = (store.getQuads(null, null, null, null) as Quad[])
+        .filter(q => {
+          const obj = q.object
+          if (obj.termType !== 'Literal' && obj.termType !== 'BlankNode' && !obj.value) return true
+          if (obj.termType === 'NamedNode' && !isValidIri(obj.value)) return true
+          return false
+        })
+      store.removeQuads(invalid)
+      return invalid.length
+    }
+
+    const SUBJECT = 'http://example.com/vocab'
+    const PRED = 'http://www.w3.org/2002/07/owl#versionIRI'
+
+    it('drops quads whose object is an empty IRI (DefaultGraph-typed in N3)', () => {
+      const store = new Store()
+      // namedNode('') gets normalised to DefaultGraph by N3
+      store.addQuad(namedNode(SUBJECT), namedNode(PRED), namedNode(''), defaultGraph())
+      expect(store.size).toBe(1)
+      const dropped = pruneInvalidQuads(store)
+      expect(dropped).toBe(1)
+      expect(store.size).toBe(0)
+    })
+
+    it('drops quads with bare scheme seed IRIs', () => {
+      const store = new Store()
+      store.addQuad(namedNode(SUBJECT), namedNode(PRED), namedNode('https://'), defaultGraph())
+      const dropped = pruneInvalidQuads(store)
+      expect(dropped).toBe(1)
+      expect(store.size).toBe(0)
+    })
+
+    it('keeps valid IRI quads', () => {
+      const store = new Store()
+      store.addQuad(namedNode(SUBJECT), namedNode(PRED), namedNode('https://example.com/v/1'), defaultGraph())
+      const dropped = pruneInvalidQuads(store)
+      expect(dropped).toBe(0)
+      expect(store.size).toBe(1)
+    })
+
+    it('keeps literal values even if empty (they are a separate concern)', () => {
+      const store = new Store()
+      store.addQuad(namedNode(SUBJECT), namedNode(`${SKOS}prefLabel`), literal(''), defaultGraph())
+      const dropped = pruneInvalidQuads(store)
+      expect(dropped).toBe(0)
+      expect(store.size).toBe(1)
+    })
+
+    it('strips multiple invalid quads in one pass', () => {
+      const store = new Store()
+      store.addQuad(namedNode(SUBJECT), namedNode(PRED), namedNode(''), defaultGraph())
+      store.addQuad(namedNode(SUBJECT), namedNode(PRED), namedNode('http://'), defaultGraph())
+      store.addQuad(namedNode(SUBJECT), namedNode(PRED), namedNode('https://example.com/ok'), defaultGraph())
+      const dropped = pruneInvalidQuads(store)
+      expect(dropped).toBe(2)
+      expect(store.size).toBe(1)
+    })
+  })
 })


### PR DESCRIPTION
Follow-up fixes for two bugs surfaced by Nick on `ga-vocabs-editor` (#28 and #29), plus a `CLAUDE.md` checklist to stop similar regressions from shipping again.

## What's in the change

### #28 — "Add agent" silently failed when a value already existed

The agent-picker's "Add agent" button defaulted to `agents[0].iri`. If that agent was already the existing value, `N3.Store.addQuad` deduplicated and the click did nothing visible.

Fix: pick the first agent NOT already in the property's values. Hide the button when every loaded agent is already in use.

### #29 — Blank IRI value produced invalid RDF

The `iri-input` widget seeded new values with `https://`. Clearing the input produced a `NamedNode('')`, which N3 normalises to a `DefaultGraph`-typed term — the Turtle writer then emits `<>` syntax (broken RDF).

Three layers of defence:
1. `validateSubject` flags empty / bare-scheme-seed IRIs on any IRI-valued shape (top-level + nested).
2. `pruneInvalidQuads` strips bad quads before serialise with a `console.warn` so the case is observable.
3. The "Add IRI" button is hidden while an existing row is still a bare scheme seed.

### `CLAUDE.md` — Widget Development Checklist

Captures the lessons:
1. Walk the lifecycle (add → edit → clear → add-second → remove → save → reload) before commit, not just "does it render".
2. Validation parity with each new field type, in the same PR.
3. Defensive serialisation review when a new value-shape is introduced.
4. Unit tests for dispatch + mutation + serialise in the same PR.
5. Profile parser parity for any new SHACL constraint the widget consumes.

## Tests

- `edit-validation`: +9 cases (empty NamedNode, bare scheme seeds, whitespace, malformed IRIs, plus widget-helper pure functions).
- `serialize-with-patch`: +5 cases for `pruneInvalidQuads` (empty IRI, bare seeds, mixed valid/invalid, literal preservation).
- All 359 existing tests still pass.

## Test plan

- [ ] Profile parser parity unchanged (`pnpm --filter @prez-lite/web exec vitest run tests/unit/`)
- [ ] On the live site after deploy, click Add agent — adds a different agent each time, hides when all agents are used.
- [ ] Click Add IRI, clear the seeded `https://`, observe the validation flag and Save being blocked. Re-fill → flag clears.