### PR TITLE
feat: resolve background labels in formatIri for dropdown options

### DIFF
--- a/web/app/components/ConceptForm.vue
+++ b/web/app/components/ConceptForm.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { EditableProperty, EditableValue, ConceptSummary, SubjectChange } from '~/composables/useEditMode'
+import { resolveIriLabel } from '~/utils/vocab-labels'
 
 const props = defineProps<{
   subjectIri: string
@@ -126,13 +127,13 @@ function confirmDelete() {
   emit('delete')
 }
 
-/** Format an IRI for readonly display — show prefLabel if available */
+/** Format an IRI for display — prefer the current vocab's prefLabel, then
+ *  the background-labels store (Data Themes, reg-statuses, etc.), then
+ *  fall back to the local-name slice (#26). */
 function formatIri(iri: string): string {
   const concept = props.concepts.find(c => c.iri === iri)
   if (concept) return concept.prefLabel
-  const hashIdx = iri.lastIndexOf('#')
-  const slashIdx = iri.lastIndexOf('/')
-  return iri.substring(Math.max(hashIdx, slashIdx) + 1)
+  return resolveIriLabel(iri)
 }
 </script>
 

--- a/web/app/components/InlineEditTable.vue
+++ b/web/app/components/InlineEditTable.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { EditableProperty, EditableValue, EditableNestedProperty, ConceptSummary, SubjectChange, AgentEntry, ValidationError } from '~/composables/useEditMode'
+import { resolveIriLabel } from '~/utils/vocab-labels'
 
 const props = defineProps<{
   subjectIri: string
@@ -289,11 +290,13 @@ function formatAgent(iri: string): string {
 }
 
 function formatIri(iri: string): string {
+  // 1. Current vocab's own concepts (skos:broader / related pickers etc.)
   const concept = props.concepts.find(c => c.iri === iri)
   if (concept) return concept.prefLabel
-  const hashIdx = iri.lastIndexOf('#')
-  const slashIdx = iri.lastIndexOf('/')
-  return iri.substring(Math.max(hashIdx, slashIdx) + 1)
+  // 2. Background labels (issue #26 — Data Themes, reg-statuses, etc. live in
+  //    data/background/*.ttl and the editor seeded the runtime label store
+  //    from /export/system/labels.json). Falls back to the local-name slice.
+  return resolveIriLabel(iri)
 }
 
 function formatValue(val: EditableValue): string {


### PR DESCRIPTION
Supporting change for [GA #26](https://github.com/Kurrawong/ga-vocabs-editor/issues/26). The select widget's dropdown options were going through \`formatIri\`, which only knew about the *current* vocab's concepts and otherwise fell back to the local-name slice. External-vocab IRIs (Reg Statuses, Data Themes) displayed as raw underscored slugs in the dropdown.

This change has \`formatIri\` fall through to \`resolveIriLabel\` from \`~/utils/vocab-labels\` when the current-vocab lookup misses. That helper consults the runtime label store seeded from \`/export/system/labels.json\` (the same source the read-view rendering already uses), so any IRI with a label in \`data/background/*.ttl\` renders nicely without further plumbing.

## Test plan

- [ ] Companion GA PR adds the Data Themes vocab to background labels and enumerates its 31 IRIs in \`sh:in\` on \`sdo:keywords\`. After both deploy, opening the keywords field on any scheme should show a dropdown with human-readable theme names ("administration", "geophysics", "sample acquisition and management", etc.) rather than slugs.
- [ ] No regressions: all 392 unit tests still pass; \`resolveIriLabel\` has its own tests in \`vocab-labels.test.ts\`.
- [ ] Existing dropdowns that already worked (Reg Statuses on \`reg:status\`) continue to work — their IRIs were already in labels.json.