### PR TITLE
fix(ci): keep branch ref for fetch-prez-lite-tools

### DIFF
--- a/.github/workflows/site-deploy-aws.yml
+++ b/.github/workflows/site-deploy-aws.yml
@@ -88,7 +88,13 @@ jobs:
         id: tools
         uses: Kurrawong/prez-lite/.github/actions/fetch-prez-lite-tools@main
         with:
-          prez-lite-ref: ${{ steps.resolve-sha.outputs.sha }}
+          # Pass the original ref (branch/tag/SHA) here — the action's
+          # `git clone -b` only accepts branch/tag names, and `git clone`
+          # uses git protocol, not codeload, so it's not affected by the
+          # tarball cache that motivates the resolve-sha step. The SHA is
+          # only needed for the Nuxt layer fetch (codeload-based) further
+          # down.
+          prez-lite-ref: ${{ inputs.prez-lite-ref }}
           node-version: ${{ inputs.node-version }}
 
       - name: Process vocabularies


### PR DESCRIPTION
Follow-up to #19. The previous change passed the resolved SHA to both fetch-prez-lite-tools and the Nuxt build. But fetch-prez-lite-tools uses `git clone --depth 1 -b <ref>`, which rejects 40-char SHAs (only branch/tag names). The deploy failed at the clone step.

`git clone` doesn't go through codeload — it uses the git protocol — so it's unaffected by the codeload tarball cache. Only the Nuxt layer fetch (giget → codeload) needs the SHA pin.

Test plan: trigger a client-site deploy and watch fetch-prez-lite-tools succeed.