### PR TITLE
fix: bypass HTTP cache when fetching system JSON in enterEditMode

### DIFF
--- a/web/app/composables/useEditMode.ts
+++ b/web/app/composables/useEditMode.ts
@@ -327,14 +327,19 @@ export function useEditMode(
         'prefixes:', Object.keys(originalPrefixes.value).join(', '))
 
       // Load profile config, agents, and background labels (in parallel).
-      // labels.json seeds the runtime label store so dropdown/picker IRI
-      // values render with human prefLabels (Data Themes, reg-statuses, etc.)
-      // — the read-view path already seeds these via annotated-properties,
-      // but going straight to edit mode skips that, leaving slug-only options.
+      //
+      // `cache: 'no-store'` is deliberate: any visitor who hit the site
+      // before we set proper Cache-Control headers will have these files
+      // cached by the browser under the OLD heuristic policy (cached for
+      // days). The new server headers (max-age=0, must-revalidate) only
+      // apply to *future* fetches that pass through HTTP cache. To unblock
+      // existing users we have to bypass HTTP cache entirely on these
+      // small JSON files — they're tiny and a fresh fetch each time is
+      // cheap, and editors need them to be current to render correctly.
       const loads: Promise<void>[] = []
       if (!profileConfig.value) {
         loads.push(
-          fetch('/export/system/profile.json')
+          fetch('/export/system/profile.json', { cache: 'no-store' })
             .then(r => r.json())
             .then(data => { profileConfig.value = data })
             .catch(() => { /* Non-fatal: forms still work without ordering */ }),
@@ -342,14 +347,14 @@ export function useEditMode(
       }
       if (!agents.value.length) {
         loads.push(
-          fetch('/export/system/agents.json')
+          fetch('/export/system/agents.json', { cache: 'no-store' })
             .then(r => r.json())
             .then((data: AgentEntry[]) => { agents.value = data })
             .catch(() => { /* Non-fatal: agent picker will be empty */ }),
         )
       }
       loads.push(
-        fetch('/export/system/labels.json')
+        fetch('/export/system/labels.json', { cache: 'no-store' })
           .then(r => r.json())
           .then(data => { seedRuntimeLabels(data) })
           .catch(() => { /* Non-fatal: dropdowns fall back to local-name slugs */ }),


### PR DESCRIPTION
Visitors who hit the site before we set proper Cache-Control headers have stale copies of system JSON in their browser HTTP cache. Those cached entries carry the OLD (heuristic) cache policy, so freshly-uploaded `max-age=0,must-revalidate` headers on S3 only apply to *future* fetches that aren't served from existing cache. The new headers don't override an existing cache entry — the browser serves the existing entry without revalidating.

Visible symptom: open the editor, dropdowns show local-name slugs even though labels.json on the server has the prefLabels — because useEditMode is quietly seeding the runtime label store with a 3-week-old labels.json the browser cached before Data Themes was added.

`cache: 'no-store'` on these fetches skips HTTP cache entirely. Files are tiny (KB) and loaded once per edit-mode entry.

This is the actual user-visible bug behind GA #26 — and the same fix prevents the same class of issue affecting profile.json and agents.json.