### PR TITLE
fix: surface GitHub save errors in the SaveConfirmModal

### DIFF
--- a/web/app/components/SaveConfirmModal.vue
+++ b/web/app/components/SaveConfirmModal.vue
@@ -6,6 +6,13 @@ const props = defineProps<{
   originalTTL: string
   patchedTTL: string
   saving?: boolean
+  /**
+   * Save error from the most recent attempt (#19). When set, an alert is
+   * shown so the user can see what GitHub returned (e.g. 403 messages from
+   * a stale token or a missing App authorisation) rather than the modal
+   * silently doing nothing.
+   */
+  error?: string | null
 }>()
 
 const emit = defineEmits<{
@@ -162,11 +169,24 @@ function changeTypePrefix(type: 'added' | 'removed' | 'modified'): string {
       />
     </div>
 
+    <!-- Save failure surfacing (#19) — show the actual GitHub response so
+         users / supporters can diagnose, instead of the click silently
+         doing nothing. -->
+    <UAlert
+      v-if="error"
+      color="error"
+      variant="soft"
+      icon="i-heroicons-exclamation-triangle"
+      title="Save failed"
+      :description="error"
+      class="text-sm"
+    />
+
     <!-- Actions -->
     <div class="flex justify-end gap-2 pt-2">
       <UButton variant="ghost" :disabled="saving" @click="emit('cancel')">Cancel</UButton>
       <UButton :loading="saving" @click="handleConfirm">
-        Save to GitHub
+        {{ error ? 'Retry save' : 'Save to GitHub' }}
       </UButton>
     </div>
   </div>

--- a/web/app/composables/useEditMode.ts
+++ b/web/app/composables/useEditMode.ts
@@ -212,6 +212,13 @@ export function useEditMode(
     fallbackBranches?: Ref<string>[]
     /** Called before first save to ensure the edit branch exists */
     ensureEditBranch?: () => Promise<boolean>
+    /**
+     * Read the most recent GitHub API error from whatever helper owns the
+     * branch-creation flow (typically `useWorkspace`'s `lastGithubError`).
+     * Used to surface a real error message in the UI when `ensureEditBranch`
+     * returns false, instead of the generic "Failed to create edit branch".
+     */
+    getLastBranchError?: () => string | null
   },
 ) {
   // Core state
@@ -1110,7 +1117,10 @@ export function useEditMode(
       if (options?.ensureEditBranch) {
         const ok = await options.ensureEditBranch()
         if (!ok) {
-          error.value = 'Failed to create edit branch'
+          const detail = options.getLastBranchError?.()
+          error.value = detail
+            ? `Couldn't create the edit branch: ${detail}`
+            : 'Failed to create edit branch'
           saveStatus.value = 'error'
           return false
         }
@@ -1155,7 +1165,10 @@ export function useEditMode(
       if (options?.ensureEditBranch) {
         const ok = await options.ensureEditBranch()
         if (!ok) {
-          error.value = 'Failed to create edit branch'
+          const detail = options.getLastBranchError?.()
+          error.value = detail
+            ? `Couldn't create the edit branch: ${detail}`
+            : 'Failed to create edit branch'
           saveStatus.value = 'error'
           return false
         }

--- a/web/app/composables/useWorkspace.ts
+++ b/web/app/composables/useWorkspace.ts
@@ -7,7 +7,7 @@
  * State is stored in localStorage (persists across login redirects and page refreshes).
  */
 
-import { createGithubFetch } from '~/utils/github-fetch'
+import { createGithubFetch, type GithubFetchError } from '~/utils/github-fetch'
 
 export interface WorkspaceDefinition {
   slug: string
@@ -200,7 +200,12 @@ export function useWorkspace() {
 
   // ---- GitHub Branch API ----
 
-  const githubFetch = createGithubFetch(token, 'workspace')
+  // Structured info about the most recent failing GitHub call (status code,
+  // response body, etc.). useEditMode reads this when a save flow fails so
+  // it can surface a real error message in the UI instead of "Failed to
+  // create edit branch".
+  const lastGithubError = ref<GithubFetchError | null>(null)
+  const githubFetch = createGithubFetch(token, 'workspace', lastGithubError)
 
   async function fetchBranches() {
     if (!owner || !repo || !token.value) return
@@ -321,6 +326,8 @@ export function useWorkspace() {
     comparisons: readonly(comparisons),
     branchesLoading: readonly(branchesLoading),
     branchesError,
+    /** Structured GitHub error from the last failing branch / API call */
+    lastGithubError: readonly(lastGithubError),
 
     // Actions
     loadDefinitions,

--- a/web/app/pages/scheme.vue
+++ b/web/app/pages/scheme.vue
@@ -170,10 +170,20 @@ const monacoTheme = computed(() => colorMode.value === 'dark' ? 'prez-dark' : 'p
 // Fallback chain: edit branch → workspace branch → refreshFrom (e.g. main)
 const workspaceBranch = computed(() => workspace.activeReadBranch.value ?? defaultBranch as string)
 const refreshFromBranch = computed(() => workspace.activeWorkspace.value?.refreshFrom ?? defaultBranch as string)
+/** Format a workspace GitHub API error into a one-line UI string */
+function formatWorkspaceError(): string | null {
+  const e = workspace.lastGithubError.value
+  if (!e) return null
+  const detail = e.githubMessage || e.message
+  // "403 Forbidden — Resource not accessible by integration"
+  return e.status > 0 ? `${e.status} ${e.message.replace(/^\d+\s+/, '')}${e.githubMessage ? ` — ${e.githubMessage}` : ''}` : detail
+}
+
 const editMode = (editorOwner && editorRepoName)
   ? useEditMode(editorOwner, editorRepoName, editorFilePath as Ref<string>, effectiveBranch, uri, {
     fallbackBranches: [workspaceBranch, refreshFromBranch],
     ensureEditBranch: () => workspace.ensureEditBranch(),
+    getLastBranchError: formatWorkspaceError,
   })
   : null
 
@@ -2277,6 +2287,7 @@ function copyIriToClipboard(iri: string) {
             :original-t-t-l="saveModalOriginalTTL"
             :patched-t-t-l="saveModalPatchedTTL"
             :saving="editMode?.saveStatus.value === 'saving'"
+            :error="editMode?.saveStatus.value === 'error' ? (editMode?.error?.value ?? null) : null"
             @confirm="handleSaveConfirm"
             @cancel="showSaveModal = false"
           />

--- a/web/app/utils/github-fetch.ts
+++ b/web/app/utils/github-fetch.ts
@@ -6,10 +6,55 @@
 
 import type { Ref } from 'vue'
 
-export function createGithubFetch(token: Ref<string | null>, logPrefix = 'github') {
+/**
+ * Structured error info captured on the last failing GitHub API call. Pass a
+ * Ref of this type as the `lastError` arg to `createGithubFetch` and the
+ * helper will populate it on every non-OK response or thrown fetch error.
+ * Callers can then surface a human-readable message in the UI instead of
+ * the current silent-null failure mode.
+ */
+export interface GithubFetchError {
+  status: number
+  /** Short summary: "403 Forbidden" or "Network error" */
+  message: string
+  /** Parsed `message` from GitHub's JSON error body when present */
+  githubMessage?: string
+  /** Raw response body (truncated) for debugging */
+  body?: string
+  /** Original URL that failed */
+  url: string
+  /** HTTP method (GET/POST/...) */
+  method: string
+}
+
+/** Try to extract GitHub's `message` field from a JSON error body */
+function parseGithubMessage(body: string): string | undefined {
+  try {
+    const parsed = JSON.parse(body)
+    if (parsed && typeof parsed.message === 'string') return parsed.message
+  } catch {
+    /* not JSON */
+  }
+  return undefined
+}
+
+export function createGithubFetch(
+  token: Ref<string | null>,
+  logPrefix = 'github',
+  lastError?: Ref<GithubFetchError | null>,
+) {
   return async function githubFetch<T>(url: string, options?: RequestInit): Promise<T | null> {
+    const method = options?.method ?? 'GET'
     if (!token.value) {
       console.warn(`[${logPrefix}] No token available for GitHub API call`)
+      if (lastError) {
+        lastError.value = {
+          status: 0,
+          message: 'Not authenticated',
+          url,
+          method,
+        }
+      }
       return null
     }
     try {
@@ -24,13 +69,34 @@ export function createGithubFetch(token: Ref<string | null>, logPrefix = 'github
       })
       if (!res.ok) {
         const body = await res.text().catch(() => '')
-        console.error(`[${logPrefix}] GitHub API ${options?.method ?? 'GET'} ${url} → ${res.status}: ${body}`)
+        console.error(`[${logPrefix}] GitHub API ${method} ${url} → ${res.status}: ${body}`)
+        if (lastError) {
+          lastError.value = {
+            status: res.status,
+            message: `${res.status} ${res.statusText}`,
+            githubMessage: parseGithubMessage(body),
+            body: body.slice(0, 400),
+            url,
+            method,
+          }
+        }
         return null
       }
+      // Successful call — clear any prior error
+      if (lastError) lastError.value = null
       if (res.status === 204) return null
       return await res.json()
     } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Network error'
       console.error(`[${logPrefix}] GitHub API fetch error:`, e)
+      if (lastError) {
+        lastError.value = {
+          status: 0,
+          message: msg,
+          url,
+          method,
+        }
+      }
       return null
     }
   }


### PR DESCRIPTION
Closes the diagnostic gap that sent us on a long detour for GA [#19](https://github.com/Kurrawong/ga-vocabs-editor/issues/19) — when a save flow's GitHub call returned non-OK, the modal silently did nothing, with the real error only visible in DevTools console.

## What changes

- `createGithubFetch` accepts an optional `lastError` Ref and populates it with structured info (status, GitHub message, truncated body) on every non-OK response or thrown fetch error.
- `useWorkspace` owns one such ref (`lastGithubError`) for its branch-management calls and exposes it on the composable.
- `useEditMode.saveSubject` takes a new `getLastBranchError` callback so it can ask the caller for the workspace's structured error string when `ensureEditBranch` returns false.
- `scheme.vue` formats the structured error into a readable one-liner ("403 Forbidden — Resource not accessible by integration") and passes it to SaveConfirmModal.
- `SaveConfirmModal` renders a UAlert above the action buttons when `error` is set, and the button label changes "Save to GitHub" → "Retry save" so the next attempt is intentional.

The file-write path (`useGitHubFile.save`) already captures GitHub error messages — this PR closes the gap on the branch-creation path.

## Test plan

- [ ] Sign in as a user with read-only access on a write-attempted repo, try to save → modal now shows "403 Forbidden — Resource not accessible by integration" instead of doing nothing.
- [ ] Sign in as a user with proper write access → modal closes after success, no spurious error shown.
- [ ] Existing call sites (`usePromotion`) continue to work — they don't pass `lastError` so behaviour is unchanged for them.