### PR TITLE
fix: harden promotion re-entry against stale PR/branch state (#41)

### DIFF
--- a/web/app/composables/usePromotion.ts
+++ b/web/app/composables/usePromotion.ts
@@ -8,7 +8,7 @@
  * Provides: PR detection, creation, comment reading/posting.
  */
 
-import { createGithubFetch } from '~/utils/github-fetch'
+import { createGithubFetch, type GithubFetchError } from '~/utils/github-fetch'
 import { fetchVocabMetadata } from '~/composables/useVocabData'
 import type { SubjectChange } from '~/composables/useEditMode'
 
@@ -104,7 +104,11 @@ export function usePromotion(
   const { token } = useGitHubAuth()
   const { owner, repo } = workspace
 
-  const githubFetch = createGithubFetch(token, 'promotion')
+  // Capture structured errors from GitHub reads so failures surface to the
+  // user instead of collapsing to a silent null (which the UI misreads as
+  // "no PR exists"). See #41.
+  const lastFetchError = ref<GithubFetchError | null>(null)
+  const githubFetch = createGithubFetch(token, 'promotion', lastFetchError)
 
   const branchPR = ref<PRInfo | null>(null)
   const stagingPR = ref<PRInfo | null>(null)
@@ -147,6 +151,12 @@ export function usePromotion(
         stagingPR.value = data?.length ? toPRInfo(data[0]!) : null
       } else {
         stagingPR.value = null
+      }
+
+      // A null PR ref can mean "no PR" OR "the lookup failed". Surface the
+      // latter so the UI doesn't silently offer Submit on an already-open PR.
+      if (lastFetchError.value) {
+        error.value = lastFetchError.value.githubMessage ?? lastFetchError.value.message
       }
     } catch (e: unknown) {
       error.value = e instanceof Error ? e.message : 'Failed to check PRs'

--- a/web/app/composables/useWorkspace.ts
+++ b/web/app/composables/useWorkspace.ts
@@ -177,7 +177,15 @@ export function useWorkspace() {
     const wsOk = await ensureWorkspaceBranch()
     if (!wsOk) return false
 
-    if (branches.value.some(b => b.name === branchName)) return true
+    if (branches.value.some(b => b.name === branchName)) {
+      // An edit branch left over from an abandoned session holds stale content;
+      // useGitHubFile.load() reads the edit branch first, so reusing it would
+      // load outdated TTL. Reset it to the workspace branch head so editing
+      // always starts from current state (#41). Discards any un-merged commits
+      // on the edit branch — intended, edit branches are ephemeral.
+      await resetBranch(branchName, ws.slug)
+      return true
+    }
 
     // Create from the workspace branch (e.g. staging)
     const created = await createBranch(branchName, ws.slug)
@@ -275,6 +283,36 @@ export function useWorkspace() {
     if (!data) return false
 
     // Refresh branch list
+    await fetchBranches()
+    return true
+  }
+
+  /**
+   * Force-reset an existing branch to the head of `fromBranch`, discarding any
+   * commits unique to it. Used to refresh a stale edit branch on re-entry (#41).
+   */
+  async function resetBranch(name: string, fromBranch: string): Promise<boolean> {
+    if (!owner || !repo || !token.value) return false
+
+    // Resolve the source branch SHA (cache first, then API)
+    let sha = branches.value.find(b => b.name === fromBranch)?.sha
+    if (!sha) {
+      const branchData = await githubFetch<{ commit: { sha: string } }>(
+        `https://api.github.com/repos/${owner}/${repo}/branches/${encodeURIComponent(fromBranch)}`,
+      )
+      sha = branchData?.commit?.sha
+    }
+    if (!sha) return false
+
+    const data = await githubFetch<{ ref: string }>(
+      `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/${encodeURIComponent(name)}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ sha, force: true }),
+      },
+    )
+    if (!data) return false
+
     await fetchBranches()
     return true
   }

--- a/web/app/pages/scheme.vue
+++ b/web/app/pages/scheme.vue
@@ -241,9 +241,11 @@ const prRejecting = ref(false)
 const prCommenting = ref(false)
 const promotionError = ref<string | null>(null)
 
-function handlePromote(layerName: 'pending' | 'approved') {
+async function handlePromote(layerName: 'pending' | 'approved') {
   promotionError.value = null
   promotionLayer.value = layerName
+  // Refresh live PR state first so we don't offer Submit on an already-open PR (#41)
+  if (promotion) await promotion.findExistingPRs(true)
   promotionMode.value = 'create'
   showReviewModal.value = true
 }
@@ -255,6 +257,8 @@ async function handleViewPR(layerName: 'pending' | 'approved') {
   prCommentsLoading.value = true
   showReviewModal.value = true
 
+  // Force a fresh lookup so the review screen reflects current PR state (#41)
+  if (promotion) await promotion.findExistingPRs(true)
   const pr = layerName === 'pending' ? promotion?.branchPR.value : promotion?.stagingPR.value
   if (pr && promotion) {
     prComments.value = await promotion.getPRComments(pr.number)

--- a/web/app/pages/workspace.vue
+++ b/web/app/pages/workspace.vue
@@ -148,8 +148,10 @@ const prRejecting = ref(false)
 const prCommenting = ref(false)
 const promotionError = ref<string | null>(null)
 
-function handleSubmitForPublishing() {
+async function handleSubmitForPublishing() {
   promotionError.value = null
+  // Refresh live PR state first so we don't offer Submit on an already-open PR (#41)
+  await promotion.findExistingPRs(true)
   promotionMode.value = 'create'
   showReviewModal.value = true
 }
@@ -160,6 +162,8 @@ async function handleViewPR() {
   prCommentsLoading.value = true
   showReviewModal.value = true
 
+  // Force a fresh lookup so the review screen reflects current PR state (#41)
+  await promotion.findExistingPRs(true)
   const pr = promotion.stagingPR.value
   if (pr) {
     prComments.value = await promotion.getPRComments(pr.number)

--- a/web/tests/unit/promotion.test.ts
+++ b/web/tests/unit/promotion.test.ts
@@ -278,3 +278,69 @@ describe('usePromotion API orchestration', () => {
     expect(body).toContain('Properties changed')
   })
 })
+
+// ---------------------------------------------------------------------------
+// Structured error capture (#41 slice 2): a failed PR lookup must surface a
+// real error instead of collapsing to a silent null the UI reads as "no PR".
+// ---------------------------------------------------------------------------
+
+describe('createGithubFetch lastError capture', () => {
+  const token = ref<string | null>('test-token')
+  let mockFetch: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    mockFetch = vi.fn()
+    vi.stubGlobal('fetch', mockFetch)
+  })
+
+  it('populates lastError with status + GitHub message on a non-OK response', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      text: async () => JSON.stringify({ message: 'Resource not accessible by integration' }),
+    })
+
+    const { createGithubFetch } = await import('~/utils/github-fetch')
+    const lastError = ref<import('~/utils/github-fetch').GithubFetchError | null>(null)
+    const githubFetch = createGithubFetch(token, 'test', lastError)
+
+    const result = await githubFetch('https://api.github.com/repos/o/r/pulls?state=open')
+
+    expect(result).toBeNull()
+    expect(lastError.value).not.toBeNull()
+    expect(lastError.value!.status).toBe(403)
+    expect(lastError.value!.githubMessage).toBe('Resource not accessible by integration')
+  })
+
+  it('clears lastError after a subsequent successful call', async () => {
+    const { createGithubFetch } = await import('~/utils/github-fetch')
+    const lastError = ref<import('~/utils/github-fetch').GithubFetchError | null>(null)
+    const githubFetch = createGithubFetch(token, 'test', lastError)
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false, status: 404, statusText: 'Not Found', text: async () => '{}',
+    })
+    await githubFetch('https://api.github.com/repos/o/r/pulls')
+    expect(lastError.value).not.toBeNull()
+
+    // A later success must clear it, else it reads as a stale failure
+    mockFetch.mockResolvedValueOnce({
+      ok: true, status: 200, json: async () => [],
+    })
+    await githubFetch('https://api.github.com/repos/o/r/pulls')
+    expect(lastError.value).toBeNull()
+  })
+
+  it('captures "Not authenticated" when there is no token', async () => {
+    const { createGithubFetch } = await import('~/utils/github-fetch')
+    const lastError = ref<import('~/utils/github-fetch').GithubFetchError | null>(null)
+    const noToken = ref<string | null>(null)
+    const githubFetch = createGithubFetch(noToken, 'test', lastError)
+
+    const result = await githubFetch('https://api.github.com/repos/o/r/pulls')
+
+    expect(result).toBeNull()
+    expect(lastError.value?.message).toBe('Not authenticated')
+  })
+})


### PR DESCRIPTION
Relief-path fixes for Kurrawong/ga-vocabs-editor#41 — "unable to complete the publishing workflow from the Admin UI" after an interrupted/abandoned review.

## Root cause
Review state lives only in volatile `branchPR`/`stagingPR` refs, populated by a 30s-throttled, watch-driven lookup. On re-entry the refs can be stale-null (throttle, token-hydration race, or a swallowed API error), which makes action handlers silently no-op *or* makes the UI offer "Submit" on an already-open PR → 422.

## Changes (3 slices)
1. **Force-refresh on entry** — `handleViewPR` + submit/promote entries (`scheme.vue`, `workspace.vue`) call `findExistingPRs(true)` so the screen reflects live PR state.
2. **Surface read errors** — `usePromotion` wires the structured `lastFetchError` ref into `createGithubFetch`; a failed lookup now sets `error.value` instead of looking like "no PR".
3. **Refresh stale edit branches** — `ensureEditBranch` force-resets an existing edit branch to the workspace-branch head (new `resetBranch`), so `useGitHubFile.load()` (which reads the edit branch first) can't load outdated TTL from an abandoned session. Discards un-merged commits on the edit branch by design.

## Tests
+3 unit tests covering `createGithubFetch` `lastError` capture/clear/no-token (the slice-2 mechanism, previously untested). All 14 promotion + 18 workspace tests pass.

## Deferred (follow-up "rock-solid" pass)
`resetBranch` and the full re-entry scenario matrix need a stateful GitHub fake (models the PR lifecycle + controllable clock); that harness is the keystone tracked separately. Note Kurrawong/ga-vocabs-editor#43 is already resolved by detaching that repo from its fork network.
