### PR TITLE
fix: set workspace vocab context when entering edit mode from any path

### DIFF
--- a/web/app/pages/scheme.vue
+++ b/web/app/pages/scheme.vue
@@ -810,6 +810,15 @@ const editErrorPath = ref('')
 // On page load auth token and vocab metadata may not be available yet, so watch all three.
 watch([editView, authToken, vocabSlugForEditor], async ([view]) => {
   if (view !== 'none' && editMode && !editMode.isEditMode.value && vocabSlugForEditor.value) {
+    // Bind the workspace's vocab context to the vocab being edited. Reaching the
+    // editor via the home → vocab card path doesn't go through the workspace
+    // dashboard (which is the only place that calls selectVocab), so vocabSlug
+    // would otherwise stay null and ensureEditBranch() fails the first save with
+    // "Failed to create edit branch". Set it here so every entry path works.
+    if (workspace.activeWorkspace.value
+      && workspace.activeVocabSlug.value !== vocabSlugForEditor.value) {
+      await workspace.selectVocab(vocabSlugForEditor.value)
+    }
     await editMode.enterEditMode()
     if (editMode.error.value) {
       editErrorMessage.value = editMode.error.value


### PR DESCRIPTION
**Bug (found during live E2E testing of the GA editor):** opening a vocab from the **home page card** and editing it, then saving, fails with **"Failed to create edit branch"** — and no GitHub call is even made.

**Cause:** `selectVocab()` is only called from the workspace dashboard. The home → vocab-card path never sets it, so workspace state stays `{ workspaceSlug: "develop", vocabSlug: null }`. With `vocabSlug` null, `activeBranch` falls back to the bare workspace slug and `ensureEditBranch()` returns `false` at its first guard (`if (!state.value?.vocabSlug) return false`).

**Fix:** the scheme page's auto-enter-edit watcher now binds the workspace vocab context (`selectVocab(vocabSlugForEditor)`) before entering edit mode, so every entry path yields a valid edit branch on save.

**Verification:** live end-to-end edit run (the manual screenshot test that surfaced this). A `useWorkspace` unit test wouldn't catch it — the defect is in the scheme-page wiring, and `useWorkspace` itself behaves correctly.