### PR TITLE
fix: stop publish flow from deleting the workspace branch

### DIFF
--- a/web/app/composables/useWorkspace.ts
+++ b/web/app/composables/useWorkspace.ts
@@ -326,6 +326,15 @@ export function useWorkspace() {
   async function deleteBranch(name: string): Promise<boolean> {
     if (!owner || !repo || !token.value) return false
 
+    // Safety net: never delete a protected branch (main + every workspace root
+    // slug, e.g. develop/staging). Only ephemeral edit branches
+    // (edit/<workspace>/<vocab>) should ever be deleted. This guards against any
+    // caller mistakenly passing a workspace branch as the merge head.
+    if (protectedBranches.value.has(name)) {
+      console.warn(`[workspace] Refusing to delete protected branch: ${name}`)
+      return false
+    }
+
     try {
       const res = await fetch(
         `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/${encodeURIComponent(name)}`,

--- a/web/app/pages/workspace.vue
+++ b/web/app/pages/workspace.vue
@@ -201,19 +201,18 @@ async function handleMergePR() {
   const pr = promotion.stagingPR.value
   if (!pr) return
 
-  const branches = promotion.getBranches('approved')
-
   prMerging.value = true
   promotionError.value = null
   const ok = await promotion.mergePR(pr.number)
   prMerging.value = false
 
   if (ok) {
-    // Delete staging branch after merge — it's now merged into main.
-    // A fresh branch will be created lazily on next save.
-    if (branches) {
-      await workspace.deleteBranch(branches.head)
-    }
+    // NB: do NOT delete the head branch here. For publishing (Layer 3) the head
+    // is the workspace root branch (e.g. develop) — a long-lived integration
+    // branch, not an ephemeral edit branch. Deleting it removed the workspace
+    // branch entirely and broke the workspace until it was recreated. Ephemeral
+    // edit-branch cleanup happens in the Layer 2 flow (scheme.vue), guarded to
+    // promotionLayer === 'pending'.
     await workspace.fetchBranches()
     changedVocabs.value = await promotion.fetchChangedVocabs()
   } else {
@@ -225,8 +224,6 @@ async function handleRejectPR(comment: string) {
   const pr = promotion.stagingPR.value
   if (!pr) return
 
-  const branches = promotion.getBranches('approved')
-
   prRejecting.value = true
   promotionError.value = null
   const ok = await promotion.closePR(pr.number, comment)
@@ -235,12 +232,10 @@ async function handleRejectPR(comment: string) {
   if (ok) {
     showReviewModal.value = false
 
-    // Delete the staging branch to discard conflicting/rejected changes
-    // A fresh staging branch will be created on next save
-    if (branches) {
-      await workspace.deleteBranch(branches.head)
-    }
-
+    // NB: do NOT delete the head branch on reject. For publishing the head is
+    // the workspace root branch (e.g. develop); its accumulated changes must
+    // survive a rejected publish so they can be re-submitted. Only the PR is
+    // closed. (Deleting develop here previously discarded all workspace work.)
     await workspace.fetchBranches()
     promotion.findExistingPRs(true)
     changedVocabs.value = await promotion.fetchChangedVocabs()

--- a/web/tests/unit/workspace.test.ts
+++ b/web/tests/unit/workspace.test.ts
@@ -152,6 +152,53 @@ describe('protected branches from definitions', () => {
   })
 })
 
+describe('branch deletion safety (publish must not delete the workspace branch)', () => {
+  // Mirrors the guard added to useWorkspace.deleteBranch: a branch may only be
+  // deleted when it is NOT protected (main + every workspace root slug).
+  function canDelete(name: string, protectedSet: Set<string>): boolean {
+    return !protectedSet.has(name)
+  }
+
+  // Mirrors usePromotion.getBranches for the two promotion layers.
+  function getBranches(
+    layer: 'pending' | 'approved',
+    ws: WorkspaceDefinition,
+    editBranch: string,
+  ): { head: string; base: string } {
+    if (layer === 'pending') return { head: editBranch, base: ws.slug }
+    return { head: ws.slug, base: ws.refreshFrom }
+  }
+
+  const ws: WorkspaceDefinition = { slug: 'develop', label: 'Develop', description: '', refreshFrom: 'master' }
+  const protectedSet = new Set(['main', 'develop', 'staging'])
+  const editBranch = 'edit/develop/AssociationType'
+
+  it('Layer 3 (approved/publish) head is the workspace root branch', () => {
+    expect(getBranches('approved', ws, editBranch).head).toBe('develop')
+  })
+
+  it('refuses to delete the workspace branch published in Layer 3 (the bug)', () => {
+    const head = getBranches('approved', ws, editBranch).head
+    expect(canDelete(head, protectedSet)).toBe(false)
+  })
+
+  it('Layer 2 (pending) head is the ephemeral edit branch', () => {
+    expect(getBranches('pending', ws, editBranch).head).toBe(editBranch)
+  })
+
+  it('still allows deleting the ephemeral edit branch (Layer 2 cleanup)', () => {
+    const head = getBranches('pending', ws, editBranch).head
+    expect(canDelete(head, protectedSet)).toBe(true)
+  })
+
+  it('refuses main and every workspace slug, allows edit/* branches', () => {
+    expect(canDelete('main', protectedSet)).toBe(false)
+    expect(canDelete('develop', protectedSet)).toBe(false)
+    expect(canDelete('staging', protectedSet)).toBe(false)
+    expect(canDelete('edit/staging/colours', protectedSet)).toBe(true)
+  })
+})
+
 describe('workspace label', () => {
   function deriveLabel(
     state: WorkspaceState | null,


### PR DESCRIPTION
## Problem
Publishing a workspace to production (`develop → master`) deleted the **`develop`** branch — and rejecting a publish did the same while also discarding all un-published work on `develop`. The workspace then broke (its branch no longer existed) until recreated. Repo `delete_branch_on_merge` is `false`; the deletion came from the app.

## Root cause
`workspace.vue` `handleMergePR` / `handleRejectPR` operate on the Layer 3 (publish) PR and call `deleteBranch(getBranches('approved').head)`. For the publish layer, `head` is the **workspace root branch** (e.g. `develop`), a long-lived integration branch — not an ephemeral `edit/*` branch. `scheme.vue` already guards the equivalent deletion to `promotionLayer === 'pending'`; `workspace.vue` had no such guard.

## Fix
- **workspace.vue**: don't delete the head branch on publish merge/reject. Ephemeral `edit/*` cleanup still happens in the Layer 2 (`scheme.vue`) flow.
- **useWorkspace.deleteBranch**: refuse to delete protected branches (`main` + every workspace root slug) as defense-in-depth.
- **tests**: branch-deletion-safety unit coverage (all 418 unit/component tests pass).

## How it was found
End-to-end editor test (create concept → save → submit for approval → publish): after "Publish to Production", the `develop` branch had vanished and had to be recreated from `master`.