### PR TITLE
feat: create new vocabularies from the editor UI

### DIFF
--- a/web/app/components/CreateVocabModal.vue
+++ b/web/app/components/CreateVocabModal.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import { slugify } from '~/composables/useVocabCreate'
+
+const props = defineProps<{
+  creating: boolean
+  error?: string | null
+  /** IRI base learned from existing vocabularies, e.g. https://.../def/voc/ga/ */
+  iriBase: string
+}>()
+
+const emit = defineEmits<{
+  create: [payload: { title: string; definition: string; slug: string; iri: string }]
+  close: []
+}>()
+
+const title = ref('')
+const definition = ref('')
+const slug = ref('')
+const base = ref(props.iriBase)
+const slugEdited = ref(false)
+
+watch(() => props.iriBase, (v) => { if (!base.value) base.value = v })
+
+// Auto-derive the slug from the title until the user edits it directly.
+watch(title, (v) => {
+  if (!slugEdited.value) slug.value = slugify(v)
+})
+
+function onSlugInput() {
+  slugEdited.value = true
+}
+
+const normalisedBase = computed(() => {
+  const b = base.value.trim().replace(/\/+$/, '')
+  return b ? `${b}/` : ''
+})
+
+const iri = computed(() => `${normalisedBase.value}${slug.value.trim()}`)
+
+const slugValid = computed(() => /^[A-Za-z0-9_-]+$/.test(slug.value.trim()))
+const canSubmit = computed(() =>
+  !!title.value.trim() && !!definition.value.trim() && slugValid.value && /^https?:\/\/.+/.test(iri.value),
+)
+
+function submit() {
+  if (!canSubmit.value || props.creating) return
+  emit('create', {
+    title: title.value.trim(),
+    definition: definition.value.trim(),
+    slug: slug.value.trim(),
+    iri: iri.value,
+  })
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <p class="text-sm text-muted">
+      Create a new vocabulary in this workspace. A SKOS ConceptScheme is scaffolded
+      on your edit branch and opened in the editor so you can add concepts.
+    </p>
+
+    <UAlert
+      v-if="error"
+      color="error"
+      icon="i-heroicons-exclamation-triangle"
+      :description="error"
+    />
+
+    <!-- Title -->
+    <div>
+      <label class="text-sm font-medium mb-1 block">Title <span class="text-error">*</span></label>
+      <UInput v-model="title" class="w-full" placeholder="e.g. Rock Classification" autofocus />
+    </div>
+
+    <!-- Description -->
+    <div>
+      <label class="text-sm font-medium mb-1 block">Description <span class="text-error">*</span></label>
+      <UTextarea v-model="definition" class="w-full" :rows="3" placeholder="What this vocabulary covers." />
+    </div>
+
+    <!-- Identifier -->
+    <div>
+      <label class="text-sm font-medium mb-1 block">Identifier <span class="text-error">*</span></label>
+      <UInput
+        v-model="slug"
+        class="w-full"
+        placeholder="RockClassification"
+        :color="slug && !slugValid ? 'error' : undefined"
+        @input="onSlugInput"
+      />
+      <p v-if="slug && !slugValid" class="text-xs text-error mt-1">
+        Letters, numbers, hyphens and underscores only.
+      </p>
+      <p class="text-xs text-muted mt-1">
+        File: <code>{{ slug || '…' }}.ttl</code>
+      </p>
+    </div>
+
+    <!-- IRI preview -->
+    <div>
+      <label class="text-sm font-medium mb-1 block">IRI</label>
+      <UInput v-model="base" class="w-full font-mono text-xs" placeholder="https://example.org/def/voc/" />
+      <p class="text-xs text-muted mt-1 break-all">
+        New vocabulary IRI: <code>{{ iri || '…' }}</code>
+      </p>
+    </div>
+
+    <div class="flex justify-end items-center gap-3 pt-2">
+      <UButton variant="ghost" color="neutral" :disabled="creating" @click="emit('close')">
+        Cancel
+      </UButton>
+      <UButton
+        icon="i-heroicons-plus"
+        :loading="creating"
+        :disabled="!canSubmit || creating"
+        @click="submit"
+      >
+        Create vocabulary
+      </UButton>
+    </div>
+  </div>
+</template>

--- a/web/app/composables/useVocabCreate.ts
+++ b/web/app/composables/useVocabCreate.ts
@@ -1,0 +1,214 @@
+/**
+ * useVocabCreate composable
+ *
+ * Creates a brand-new vocabulary (SKOS ConceptScheme) from the UI. The editor
+ * itself only edits existing vocabularies, so this scaffolds a minimal
+ * ConceptScheme TTL file on the workspace's edit branch and makes it visible to
+ * the editor immediately (before CI reprocesses the generated index.json).
+ *
+ * Flow:
+ *   1. selectVocab(slug) + ensureEditBranch()  → edit/<workspace>/<slug>
+ *   2. PUT data/vocabs/<slug>.ttl (file creation) to the edit branch
+ *   3. injectVocab() + refreshNuxtData() so useScheme / useShare resolve it
+ *   4. caller navigates to /scheme?uri=<iri> to add concepts via the normal flow
+ */
+
+import { createGithubFetch, type GithubFetchError } from '~/utils/github-fetch'
+import { injectVocab, fetchVocabMetadata } from '~/composables/useVocabData'
+
+const SKOS = 'http://www.w3.org/2004/02/skos/core#'
+
+/** Derive a filename-safe slug from a free-text title (preserves casing). */
+export function slugify(title: string): string {
+  const s = (title || '')
+    .trim()
+    .replace(/[^A-Za-z0-9 _-]/g, '') // drop characters unsafe in a filename / IRI segment
+    .replace(/\s+/g, '') // join words, keeping existing capitalisation
+    .slice(0, 80)
+  return s || 'vocabulary'
+}
+
+/**
+ * Derive the IRI base (everything up to and including the final slash) from the
+ * existing vocabularies, picking the most common base so a new vocab's IRI
+ * matches the site's convention (e.g. https://pid.geoscience.gov.au/def/voc/ga/).
+ * Returns '' when there are no existing vocabs to learn from.
+ */
+export function deriveIriBase(iris: string[]): string {
+  const counts = new Map<string, number>()
+  for (const iri of iris) {
+    const base = iri.replace(/\/+$/, '').replace(/[^/]+$/, '')
+    if (base && base !== iri.replace(/\/+$/, '')) {
+      counts.set(base, (counts.get(base) ?? 0) + 1)
+    }
+  }
+  let best = ''
+  let bestN = 0
+  for (const [base, n] of counts) {
+    if (n > bestN) {
+      best = base
+      bestN = n
+    }
+  }
+  return best
+}
+
+/** Escape a string for safe inclusion in a TTL double-quoted literal. */
+export function escapeTtlLiteral(s: string): string {
+  return (s || '')
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\r/g, '')
+    .replace(/\n/g, '\\n')
+}
+
+/**
+ * Build a minimal valid ConceptScheme TTL. `:` is the concept namespace
+ * (trailing slash) and `cs:` is the scheme IRI itself, matching the convention
+ * the editor and existing vocab files use.
+ */
+export function scaffoldSchemeTTL(iri: string, title: string, definition: string): string {
+  const t = escapeTtlLiteral(title)
+  const d = escapeTtlLiteral(definition)
+  return `PREFIX : <${iri}/>
+PREFIX cs: <${iri}>
+PREFIX skos: <${SKOS}>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX schema: <https://schema.org/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+cs:
+    a skos:ConceptScheme ;
+    skos:prefLabel "${t}"@en ;
+    skos:definition "${d}"@en ;
+.
+`
+}
+
+/** UTF-8 safe base64 (browser btoa mangles multi-byte chars on its own). */
+function toBase64(str: string): string {
+  if (typeof btoa === 'function') {
+    return btoa(unescape(encodeURIComponent(str)))
+  }
+  // Test / SSR fallback
+  return Buffer.from(str, 'utf-8').toString('base64')
+}
+
+export interface CreateVocabInput {
+  title: string
+  definition: string
+  slug: string
+  iri: string
+}
+
+export interface CreateVocabResult {
+  ok: boolean
+  iri?: string
+  slug?: string
+  error?: string
+}
+
+export function useVocabCreate() {
+  const workspace = useWorkspace()
+  const { token } = useGitHubAuth()
+  const { githubVocabPath } = useRuntimeConfig().public
+  const { owner, repo } = workspace
+
+  const lastError = ref<GithubFetchError | null>(null)
+  const githubFetch = createGithubFetch(token, 'vocab-create', lastError)
+
+  const creating = ref(false)
+  const error = ref<string | null>(null)
+
+  const vocabPath = ((githubVocabPath as string) || 'data/vocabs').replace(/^\/+|\/+$/g, '')
+
+  /** Suggest a default IRI base learned from the existing vocabularies. */
+  async function suggestIriBase(): Promise<string> {
+    const metadata = await fetchVocabMetadata().catch(() => [])
+    return deriveIriBase(metadata.map(v => v.iri))
+  }
+
+  async function createVocabulary(input: CreateVocabInput): Promise<CreateVocabResult> {
+    error.value = null
+    const title = input.title.trim()
+    const definition = input.definition.trim()
+    const slug = (input.slug || '').trim()
+    const iri = (input.iri || '').trim()
+
+    if (!owner || !repo || !token.value) {
+      error.value = 'Not authenticated'
+      return { ok: false, error: error.value }
+    }
+    if (!title) { error.value = 'Title is required'; return { ok: false, error: error.value } }
+    if (!definition) { error.value = 'Description is required'; return { ok: false, error: error.value } }
+    if (!slug) { error.value = 'Identifier is required'; return { ok: false, error: error.value } }
+    if (!/^[A-Za-z0-9_-]+$/.test(slug)) {
+      error.value = 'Identifier may only contain letters, numbers, hyphens and underscores'
+      return { ok: false, error: error.value }
+    }
+    if (!/^https?:\/\/.+/.test(iri)) { error.value = 'IRI must be an absolute http(s) URL'; return { ok: false, error: error.value } }
+
+    creating.value = true
+    try {
+      // Collision check against known vocabs (by IRI and slug).
+      const existing = await fetchVocabMetadata().catch(() => [])
+      if (existing.some(v => v.iri === iri)) {
+        error.value = `A vocabulary with IRI ${iri} already exists`
+        return { ok: false, error: error.value }
+      }
+      if (existing.some(v => v.slug === slug)) {
+        error.value = `A vocabulary with identifier "${slug}" already exists`
+        return { ok: false, error: error.value }
+      }
+
+      // 1. Set the workspace vocab context (derives the edit branch name).
+      await workspace.selectVocab(slug)
+      const branch = workspace.activeBranch.value
+      if (!branch) { error.value = 'No active workspace'; return { ok: false, error: error.value } }
+
+      // 2. Ensure the edit branch exists (creates edit/<workspace>/<slug>).
+      const branchOk = await workspace.ensureEditBranch()
+      if (!branchOk) {
+        error.value = lastError.value?.githubMessage ?? 'Failed to create edit branch'
+        return { ok: false, error: error.value }
+      }
+
+      // 3. Create the scaffold TTL file on the edit branch (no sha = create).
+      const ttl = scaffoldSchemeTTL(iri, title, definition)
+      const path = `${vocabPath}/${slug}.ttl`
+      const res = await githubFetch<{ content: { sha: string } }>(
+        `https://api.github.com/repos/${owner}/${repo}/contents/${path}`,
+        {
+          method: 'PUT',
+          body: JSON.stringify({
+            message: `feat: create vocabulary "${title}"`,
+            content: toBase64(ttl),
+            branch,
+          }),
+        },
+      )
+      if (!res) {
+        error.value = lastError.value?.githubMessage ?? lastError.value?.message ?? 'Failed to create vocabulary file'
+        return { ok: false, error: error.value }
+      }
+
+      // 4. Make the new vocab visible to the editor before CI reprocessing.
+      injectVocab({ iri, slug, prefLabel: title, definition, conceptCount: 0 })
+      await refreshNuxtData(['schemes', 'vocabMetadata', 'export-vocabs'])
+
+      return { ok: true, iri, slug }
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : 'Something went wrong creating the vocabulary'
+      return { ok: false, error: error.value }
+    } finally {
+      creating.value = false
+    }
+  }
+
+  return {
+    creating: readonly(creating),
+    error: readonly(error),
+    suggestIriBase,
+    createVocabulary,
+  }
+}

--- a/web/app/composables/useVocabData.ts
+++ b/web/app/composables/useVocabData.ts
@@ -204,6 +204,26 @@ export function clearCaches() {
   listConceptsPromiseCache.clear()
 }
 
+/**
+ * Inject a vocabulary into the in-memory caches so a freshly-created vocab —
+ * one that exists only on an edit branch and is not yet in the generated
+ * index.json (CI hasn't reprocessed) — is visible to the editor immediately.
+ *
+ * Idempotent by IRI. After calling this, the caller must
+ * `refreshNuxtData(['schemes', 'vocabMetadata', 'export-vocabs'])` so the
+ * useAsyncData consumers (useScheme, useShare) re-read these caches.
+ */
+export function injectVocab(meta: VocabMetadata): void {
+  if (!cachedVocabMetadata) cachedVocabMetadata = []
+  if (!cachedVocabMetadata.some(v => v.iri === meta.iri)) {
+    cachedVocabMetadata.push(meta)
+  }
+  // Keep the derived schemes cache in sync if it has already been built.
+  if (cachedSchemes && !cachedSchemes.some(s => s.iri === meta.iri)) {
+    cachedSchemes.push(metadataToScheme(meta))
+  }
+}
+
 // Fetch vocabulary metadata (new format) — cached
 export async function fetchVocabMetadata(): Promise<VocabMetadata[]> {
   if (cachedVocabMetadata) return cachedVocabMetadata

--- a/web/app/pages/workspace.vue
+++ b/web/app/pages/workspace.vue
@@ -148,6 +148,24 @@ const prRejecting = ref(false)
 const prCommenting = ref(false)
 const promotionError = ref<string | null>(null)
 
+// --- Create vocabulary ---
+const vocabCreate = useVocabCreate()
+const showCreateModal = ref(false)
+const createIriBase = ref('')
+
+async function openCreateModal() {
+  createIriBase.value = await vocabCreate.suggestIriBase()
+  showCreateModal.value = true
+}
+
+async function handleCreateVocab(payload: { title: string; definition: string; slug: string; iri: string }) {
+  const res = await vocabCreate.createVocabulary(payload)
+  if (res.ok && res.iri) {
+    showCreateModal.value = false
+    navigateTo({ path: '/scheme', query: { uri: res.iri } })
+  }
+}
+
 async function handleSubmitForPublishing() {
   promotionError.value = null
   // Refresh live PR state first so we don't offer Submit on an already-open PR (#41)
@@ -441,6 +459,22 @@ const workspaceBreadcrumbs = computed(() => {
           </div>
         </div>
 
+        <!-- Vocabularies header + create -->
+        <div class="flex items-center justify-between mt-2 mb-3">
+          <div>
+            <h2 class="text-lg font-semibold">Vocabularies</h2>
+            <p class="text-xs text-muted">Click a vocabulary to open it in the editor.</p>
+          </div>
+          <UButton
+            size="sm"
+            icon="i-heroicons-plus"
+            variant="soft"
+            @click="openCreateModal"
+          >
+            New vocabulary
+          </UButton>
+        </div>
+
         <!-- Loading vocabs -->
         <div v-if="vocabsLoading" class="py-12 text-center">
           <UIcon name="i-heroicons-arrow-path" class="size-5 animate-spin text-muted" />
@@ -457,11 +491,6 @@ const workspaceBreadcrumbs = computed(() => {
         <div v-else class="space-y-1">
           <!-- Error selecting vocab -->
           <UAlert v-if="selectError" color="error" icon="i-heroicons-exclamation-triangle" :description="selectError" class="mb-4" />
-
-          <h2 class="text-lg font-semibold mb-1">Vocabularies</h2>
-          <p class="text-xs text-muted mb-3">
-            Click a vocabulary to open it in the editor.
-          </p>
 
           <button
             v-for="vocab in vocabs"
@@ -554,6 +583,22 @@ const workspaceBreadcrumbs = computed(() => {
             @reject="handleRejectPR"
             @comment="handlePRComment"
             @close="showReviewModal = false"
+          />
+        </template>
+      </UModal>
+
+      <!-- Create Vocabulary Modal -->
+      <UModal v-model:open="showCreateModal">
+        <template #header>
+          <h3 class="font-semibold">New vocabulary</h3>
+        </template>
+        <template #body>
+          <CreateVocabModal
+            :creating="vocabCreate.creating.value"
+            :error="vocabCreate.error.value"
+            :iri-base="createIriBase"
+            @create="handleCreateVocab"
+            @close="showCreateModal = false"
           />
         </template>
       </UModal>

--- a/web/tests/unit/vocab-create.test.ts
+++ b/web/tests/unit/vocab-create.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import { Parser, Store } from 'n3'
+import { slugify, deriveIriBase, escapeTtlLiteral, scaffoldSchemeTTL } from '~/composables/useVocabCreate'
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
+const SKOS = 'http://www.w3.org/2004/02/skos/core#'
+
+describe('slugify', () => {
+  it('joins words and preserves casing', () => {
+    expect(slugify('Rock Classification')).toBe('RockClassification')
+  })
+
+  it('strips characters unsafe in a filename / IRI segment', () => {
+    expect(slugify('Hazard & Risk (v2)!')).toBe('HazardRiskv2')
+  })
+
+  it('keeps hyphens and underscores', () => {
+    expect(slugify('borehole_status-codes')).toBe('borehole_status-codes')
+  })
+
+  it('falls back to a default for empty/blank input', () => {
+    expect(slugify('   ')).toBe('vocabulary')
+    expect(slugify('@@@')).toBe('vocabulary')
+  })
+})
+
+describe('deriveIriBase', () => {
+  it('derives the base from a GA-style IRI', () => {
+    expect(deriveIriBase(['https://pid.geoscience.gov.au/def/voc/ga/associationtype']))
+      .toBe('https://pid.geoscience.gov.au/def/voc/ga/')
+  })
+
+  it('picks the most common base across vocabs', () => {
+    const base = deriveIriBase([
+      'https://pid.geoscience.gov.au/def/voc/ga/a',
+      'https://pid.geoscience.gov.au/def/voc/ga/b',
+      'https://example.org/odd/one',
+    ])
+    expect(base).toBe('https://pid.geoscience.gov.au/def/voc/ga/')
+  })
+
+  it('returns empty string when there is nothing to learn from', () => {
+    expect(deriveIriBase([])).toBe('')
+  })
+})
+
+describe('escapeTtlLiteral', () => {
+  it('escapes quotes, backslashes and newlines', () => {
+    expect(escapeTtlLiteral('a "quote" and \\ and\nnewline'))
+      .toBe('a \\"quote\\" and \\\\ and\\nnewline')
+  })
+})
+
+describe('scaffoldSchemeTTL', () => {
+  const iri = 'https://pid.geoscience.gov.au/def/voc/ga/RockClassification'
+
+  function parse(ttl: string): Store {
+    const store = new Store()
+    store.addQuads(new Parser().parse(ttl))
+    return store
+  }
+
+  it('produces a parseable, well-formed ConceptScheme', () => {
+    const ttl = scaffoldSchemeTTL(iri, 'Rock Classification', 'A vocabulary of rock classes.')
+    const store = parse(ttl)
+
+    const typeQuads = store.getQuads(iri, RDF_TYPE, `${SKOS}ConceptScheme`, null)
+    expect(typeQuads).toHaveLength(1)
+  })
+
+  it('sets prefLabel and definition as @en literals', () => {
+    const ttl = scaffoldSchemeTTL(iri, 'Rock Classification', 'A vocabulary of rock classes.')
+    const store = parse(ttl)
+
+    const labels = store.getQuads(iri, `${SKOS}prefLabel`, null, null)
+    expect(labels).toHaveLength(1)
+    expect(labels[0]!.object.value).toBe('Rock Classification')
+    expect((labels[0]!.object as { language: string }).language).toBe('en')
+
+    const defs = store.getQuads(iri, `${SKOS}definition`, null, null)
+    expect(defs).toHaveLength(1)
+    expect(defs[0]!.object.value).toBe('A vocabulary of rock classes.')
+  })
+
+  it('emits no empty or invalid quads', () => {
+    const ttl = scaffoldSchemeTTL(iri, 'X', 'Y')
+    const store = parse(ttl)
+    for (const q of store.getQuads(null, null, null, null)) {
+      expect(q.subject.value).not.toBe('')
+      expect(q.predicate.value).not.toBe('')
+      expect(q.object.value).not.toBe('')
+    }
+  })
+
+  it('escapes quotes in the title/definition so the TTL stays valid', () => {
+    const ttl = scaffoldSchemeTTL(iri, 'The "Big" Vocab', 'Defines "things" & stuff')
+    const store = parse(ttl) // must not throw
+    const labels = store.getQuads(iri, `${SKOS}prefLabel`, null, null)
+    expect(labels[0]!.object.value).toBe('The "Big" Vocab')
+  })
+})


### PR DESCRIPTION
## What
Adds a **New vocabulary** action to the workspace dashboard so editors can create a brand-new vocabulary from the UI. Previously K-Maker could only edit *existing* vocabularies — new ones had to be added as TTL files in the repo by hand.

## How it works
1. **New vocabulary** button → modal (Title, Description, Identifier with live IRI preview; IRI base is learned from existing vocabs).
2. On submit, `useVocabCreate` scaffolds a minimal valid `skos:ConceptScheme` TTL, ensures the workspace edit branch (`edit/<ws>/<slug>`), and creates `data/vocabs/<slug>.ttl` on it via the Contents API.
3. The new vocab is injected into the in-memory metadata/schemes caches (`useVocabData.injectVocab` + `refreshNuxtData`) so it's visible to the editor **before** CI reprocesses `index.json`.
4. Navigates to `/scheme?uri=<iri>` — the editor opens on the new scheme; the user adds concepts via the existing **+ Add** flow and promotes through the normal approve/publish pipeline.

## Files
- `composables/useVocabCreate.ts` (new) — slugify, IRI-base derivation, TTL scaffold, branch+file creation, cache injection
- `composables/useVocabData.ts` — `injectVocab()`
- `components/CreateVocabModal.vue` (new) — the form
- `pages/workspace.vue` — button + modal wiring
- `tests/unit/vocab-create.test.ts` (new) — slugify, IRI-base, and N3-parsed ConceptScheme scaffold validity

## Tests
All 425 unit/component tests pass (12 new). No new type errors introduced (the new files + workspace.vue are type-clean).