### PR TITLE
feat: derive new concept IRI from a label-based identifier; lock IRI after creation

### DIFF
--- a/web/app/components/ConceptForm.vue
+++ b/web/app/components/ConceptForm.vue
@@ -22,7 +22,6 @@ const emit = defineEmits<{
   'remove:value': [predicate: string, value: EditableValue]
   'update:broader': [newIris: string[], oldIris: string[]]
   'update:related': [newIris: string[], oldIris: string[]]
-  'rename': [oldIri: string, newIri: string]
   'delete': []
   'save': []
 }>()
@@ -58,24 +57,19 @@ const languageOptions = [
 ]
 
 const showDeleteConfirm = ref(false)
-const editingIri = ref(false)
-const editIriValue = ref('')
 
-function startIriEdit() {
-  editIriValue.value = props.subjectIri
-  editingIri.value = true
-}
+// The subject IRI is read-only in the UI (changing it would break back-links);
+// renaming is a manual TTL-only operation. Offer copy-to-clipboard instead.
+const iriCopied = ref(false)
 
-function commitIriEdit() {
-  const newIri = editIriValue.value.trim()
-  if (newIri && newIri !== props.subjectIri) {
-    emit('rename', props.subjectIri, newIri)
+async function copyIri() {
+  try {
+    await navigator.clipboard.writeText(props.subjectIri)
+    iriCopied.value = true
+    setTimeout(() => { iriCopied.value = false }, 1500)
+  } catch {
+    // Clipboard unavailable (e.g. insecure context) — nothing to do.
   }
-  editingIri.value = false
-}
-
-function cancelIriEdit() {
-  editingIri.value = false
 }
 
 // Local input values to prevent cursor jumping when store re-renders
@@ -140,26 +134,17 @@ function formatIri(iri: string): string {
 <template>
   <div>
     <div class="space-y-5">
-      <!-- Subject IRI -->
-      <div v-if="editingIri" class="flex items-center gap-2">
-        <UInput
-          v-model="editIriValue"
-          class="flex-1 font-mono text-sm"
-          size="sm"
-          autofocus
-          @keydown.enter="commitIriEdit"
-          @keydown.escape="cancelIriEdit"
-        />
-        <UButton size="xs" @click="commitIriEdit">Apply</UButton>
-        <UButton size="xs" variant="ghost" @click="cancelIriEdit">Cancel</UButton>
-      </div>
+      <!-- Subject IRI (read-only; copy to clipboard) -->
       <div
-        v-else
         class="text-sm text-muted font-mono break-all bg-muted/30 px-3 py-2 rounded cursor-pointer group flex items-center gap-2 hover:bg-muted/50 transition-colors"
-        @click="startIriEdit"
+        :title="iriCopied ? 'Copied' : 'Copy IRI'"
+        @click="copyIri"
       >
         <span class="flex-1">{{ subjectIri }}</span>
-        <UIcon name="i-heroicons-pencil" class="size-3.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+        <UIcon
+          :name="iriCopied ? 'i-heroicons-check' : 'i-heroicons-clipboard-document'"
+          class="size-3.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+        />
       </div>
 
       <!-- Properties -->

--- a/web/app/components/ConceptSpreadsheet.vue
+++ b/web/app/components/ConceptSpreadsheet.vue
@@ -392,7 +392,6 @@ function getExpandedProperties(iri: string): EditableProperty[] {
               @add:nested-value="(bnId, pred, type, defVal) => editMode.addNestedValue(bnId, pred, type, defVal)"
               @add:blank-node="(pred) => editMode.addBlankNode(row.original.iri, pred)"
               @remove:blank-node="(pred, bnId) => editMode.removeBlankNode(row.original.iri, pred, bnId)"
-              @rename="(oldIri, newIri) => editMode.renameSubject(oldIri, newIri)"
               @delete="editMode.deleteConcept(row.original.iri)"
             />
           </div>

--- a/web/app/components/CreateConceptModal.vue
+++ b/web/app/components/CreateConceptModal.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+import { conceptLocalName } from '~/composables/useVocabCreate'
+
+const props = defineProps<{
+  error?: string | null
+  /** Scheme IRI used as the IRI base (a trailing '/' or '#' is ensured). */
+  schemeBase: string
+}>()
+
+const emit = defineEmits<{
+  create: [payload: { prefLabel: string; localName: string }]
+  close: []
+}>()
+
+const prefLabel = ref('')
+const localName = ref('')
+const localNameEdited = ref(false)
+
+// Auto-derive the identifier from the label until the user edits it directly.
+watch(prefLabel, (v) => {
+  if (!localNameEdited.value) localName.value = conceptLocalName(v)
+})
+
+function onLocalNameInput() {
+  localNameEdited.value = true
+}
+
+const normalisedBase = computed(() => {
+  const b = (props.schemeBase || '').trim()
+  if (!b) return ''
+  return b.endsWith('/') || b.endsWith('#') ? b : `${b}/`
+})
+
+const iri = computed(() => `${normalisedBase.value}${localName.value.trim()}`)
+
+const localNameValid = computed(() => /^[A-Za-z0-9_-]+$/.test(localName.value.trim()))
+const canSubmit = computed(() => !!prefLabel.value.trim() && localNameValid.value)
+
+function submit() {
+  if (!canSubmit.value) return
+  emit('create', {
+    prefLabel: prefLabel.value.trim(),
+    localName: localName.value.trim(),
+  })
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <p class="text-sm text-muted">
+      Add a new concept to this vocabulary. Its IRI is derived from the identifier
+      below and cannot be changed once the concept exists.
+    </p>
+
+    <UAlert
+      v-if="error"
+      color="error"
+      icon="i-heroicons-exclamation-triangle"
+      :description="error"
+    />
+
+    <!-- Preferred label -->
+    <div>
+      <label class="text-sm font-medium mb-1 block">Preferred label <span class="text-error">*</span></label>
+      <UInput v-model="prefLabel" class="w-full" placeholder="e.g. Cross Reference" autofocus />
+    </div>
+
+    <!-- Identifier -->
+    <div>
+      <label class="text-sm font-medium mb-1 block">Identifier <span class="text-error">*</span></label>
+      <UInput
+        v-model="localName"
+        class="w-full"
+        placeholder="crossReference"
+        :color="localName && !localNameValid ? 'error' : undefined"
+        @input="onLocalNameInput"
+      />
+      <p v-if="localName && !localNameValid" class="text-xs text-error mt-1">
+        Letters, numbers, hyphens and underscores only.
+      </p>
+    </div>
+
+    <!-- IRI preview -->
+    <div>
+      <label class="text-sm font-medium mb-1 block">IRI</label>
+      <p class="text-xs text-muted break-all font-mono">
+        {{ iri || '…' }}
+      </p>
+    </div>
+
+    <div class="flex justify-end items-center gap-3 pt-2">
+      <UButton variant="ghost" color="neutral" @click="emit('close')">
+        Cancel
+      </UButton>
+      <UButton
+        icon="i-heroicons-plus"
+        :disabled="!canSubmit"
+        @click="submit"
+      >
+        Add concept
+      </UButton>
+    </div>
+  </div>
+</template>

--- a/web/app/components/InlineEditTable.vue
+++ b/web/app/components/InlineEditTable.vue
@@ -61,7 +61,6 @@ const emit = defineEmits<{
   'add:nested-value': [blankNodeId: string, predicate: string, type: 'iri' | 'literal', defaultValue?: string]
   'add:blank-node': [predicate: string]
   'remove:blank-node': [predicate: string, blankNodeId: string]
-  'rename': [oldIri: string, newIri: string]
   'delete': []
 }>()
 
@@ -89,24 +88,19 @@ const languageOptions = [
 
 const editingPredicate = ref<string | null>(null)
 const showDeleteConfirm = ref(false)
-const editingIri = ref(false)
-const editIriValue = ref('')
 
-function startIriEdit() {
-  editIriValue.value = props.subjectIri
-  editingIri.value = true
-}
+// The subject IRI is read-only in the UI (changing it would break back-links);
+// renaming is a manual TTL-only operation. Offer copy-to-clipboard instead.
+const iriCopied = ref(false)
 
-function commitIriEdit() {
-  const newIri = editIriValue.value.trim()
-  if (newIri && newIri !== props.subjectIri) {
-    emit('rename', props.subjectIri, newIri)
+async function copyIri() {
+  try {
+    await navigator.clipboard.writeText(props.subjectIri)
+    iriCopied.value = true
+    setTimeout(() => { iriCopied.value = false }, 1500)
+  } catch {
+    // Clipboard unavailable (e.g. insecure context) — nothing to do.
   }
-  editingIri.value = false
-}
-
-function cancelIriEdit() {
-  editingIri.value = false
 }
 
 // Watch for autoEditPredicate changes
@@ -341,26 +335,17 @@ onUnmounted(() => {
 
 <template>
   <div ref="rootRef" @click="stopEditing()">
-    <!-- Subject IRI (click-to-edit) -->
-    <div v-if="editingIri" class="flex items-center gap-2 mb-3" @click.stop>
-      <UInput
-        v-model="editIriValue"
-        class="flex-1 font-mono text-sm"
-        size="sm"
-        autofocus
-        @keydown.enter="commitIriEdit"
-        @keydown.escape="cancelIriEdit"
-      />
-      <UButton size="xs" @click="commitIriEdit">Apply</UButton>
-      <UButton size="xs" variant="ghost" @click="cancelIriEdit">Cancel</UButton>
-    </div>
+    <!-- Subject IRI (read-only; copy to clipboard) -->
     <div
-      v-else
       class="text-sm text-muted font-mono break-all bg-muted/30 px-3 py-2 rounded mb-3 cursor-pointer group flex items-center gap-2 hover:bg-muted/50 transition-colors"
-      @click.stop="startIriEdit"
+      :title="iriCopied ? 'Copied' : 'Copy IRI'"
+      @click.stop="copyIri"
     >
       <span class="flex-1">{{ subjectIri }}</span>
-      <UIcon name="i-heroicons-pencil" class="size-3.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+      <UIcon
+        :name="iriCopied ? 'i-heroicons-check' : 'i-heroicons-clipboard-document'"
+        class="size-3.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+      />
     </div>
 
     <div class="overflow-x-hidden -mx-4">

--- a/web/app/composables/useVocabCreate.ts
+++ b/web/app/composables/useVocabCreate.ts
@@ -29,6 +29,26 @@ export function slugify(title: string): string {
 }
 
 /**
+ * Derive a lowerCamelCase IRI local name from a concept's preferred label, to
+ * match this repo's existing concept IRIs (e.g. "Cross Reference" →
+ * crossReference, alongside collectiveTitle, hadDerivation). Drops unsafe
+ * characters, joins words, and lower-cases the first letter. Falls back to
+ * 'concept' for empty / blank input.
+ */
+export function conceptLocalName(label: string): string {
+  const words = (label || '')
+    .replace(/[^A-Za-z0-9 _-]/g, ' ') // unsafe chars become word separators
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+  if (words.length === 0) return 'concept'
+  const camel = words
+    .map((w, i) => (i === 0 ? w.charAt(0).toLowerCase() : w.charAt(0).toUpperCase()) + w.slice(1))
+    .join('')
+    .slice(0, 80)
+  return camel || 'concept'
+}
+
+/**
  * Derive the IRI base (everything up to and including the final slash) from the
  * existing vocabularies, picking the most common base so a new vocab's IRI
  * matches the site's convention (e.g. https://pid.geoscience.gov.au/def/voc/ga/).

--- a/web/app/pages/scheme.vue
+++ b/web/app/pages/scheme.vue
@@ -1289,28 +1289,39 @@ function scrollToMetadataProperty(predicateIri: string) {
 }
 
 // --- Add Concept ---
+const showAddConcept = ref(false)
+const addConceptError = ref<string | null>(null)
+
+// Scheme IRI used as the IRI base for new concepts (trailing '/' or '#' ensured).
+const addConceptBase = computed(() =>
+  uri.value.endsWith('/') || uri.value.endsWith('#') ? uri.value : `${uri.value}/`,
+)
 
 function handleAddConcept() {
   if (!editMode) return
+  addConceptError.value = null
+  showAddConcept.value = true
+}
 
-  // Generate a unique local name
-  const existingIris = new Set(editMode.concepts.value.map(c => c.iri))
-  const schemeBase = uri.value.endsWith('/') || uri.value.endsWith('#')
-    ? uri.value
-    : `${uri.value}/`
-  let counter = 1
-  while (existingIris.has(`${schemeBase}new-concept-${counter}`)) {
-    counter++
+function handleCreateConcept(payload: { prefLabel: string; localName: string }) {
+  if (!editMode) return
+  addConceptError.value = null
+
+  // Reject collisions with existing concept IRIs.
+  const newIri = `${addConceptBase.value}${payload.localName}`
+  if (editMode.concepts.value.some(c => c.iri === newIri)) {
+    addConceptError.value = `A concept with identifier "${payload.localName}" already exists`
+    return
   }
 
-  const localName = `new-concept-${counter}`
   const broaderIri = selectedConceptUri.value || undefined
-  const conceptIri = editMode.addConcept(localName, 'New Concept', broaderIri)
+  const conceptIri = editMode.addConcept(payload.localName, payload.prefLabel, broaderIri)
   if (conceptIri) {
     selectConcept(conceptIri)
     expandToId.value = conceptIri
     // Clear after the tree has had time to react
     setTimeout(() => { expandToId.value = undefined }, 500)
+    showAddConcept.value = false
   }
 }
 
@@ -2037,7 +2048,6 @@ function copyIriToClipboard(iri: string) {
                   @remove:value="(pred, val) => editMode!.removeValue(selectedConceptUri!, pred, val)"
                   @update:broader="(newIris, oldIris) => editMode!.syncBroaderNarrower(selectedConceptUri!, newIris, oldIris)"
                   @update:related="(newIris, oldIris) => editMode!.syncRelated(selectedConceptUri!, newIris, oldIris)"
-                  @rename="(oldIri, newIri) => { editMode!.renameSubject(oldIri, newIri); selectConcept(newIri) }"
                   @delete="editMode!.deleteConcept(selectedConceptUri!)"
                 />
 
@@ -2101,7 +2111,6 @@ function copyIriToClipboard(iri: string) {
                   @add:nested-value="(bnId, pred, type, defVal) => editMode!.addNestedValue(bnId, pred, type, defVal)"
                   @add:blank-node="(pred) => editMode!.addBlankNode(selectedConceptUri!, pred)"
                   @remove:blank-node="(pred, bnId) => editMode!.removeBlankNode(selectedConceptUri!, pred, bnId)"
-                  @rename="(oldIri, newIri) => { editMode!.renameSubject(oldIri, newIri); selectConcept(newIri) }"
                   @delete="editMode!.deleteConcept(selectedConceptUri!)"
                 />
               </template>
@@ -2370,6 +2379,21 @@ function copyIriToClipboard(iri: string) {
         </template>
       </UModal>
 
+
+      <!-- Add Concept Modal -->
+      <UModal v-model:open="showAddConcept">
+        <template #header>
+          <h3 class="font-semibold">New concept</h3>
+        </template>
+        <template #body>
+          <CreateConceptModal
+            :error="addConceptError"
+            :scheme-base="addConceptBase"
+            @create="handleCreateConcept"
+            @close="showAddConcept = false"
+          />
+        </template>
+      </UModal>
 
       <!-- Move Concept Modal -->
       <MoveConceptModal

--- a/web/tests/unit/concept-create.test.ts
+++ b/web/tests/unit/concept-create.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { conceptLocalName } from '~/composables/useVocabCreate'
+
+/** Compose a concept IRI the way CreateConceptModal / scheme.vue do. */
+function composeConceptIri(schemeBase: string, localName: string): string {
+  const b = schemeBase.trim()
+  const base = b.endsWith('/') || b.endsWith('#') ? b : `${b}/`
+  return `${base}${localName.trim()}`
+}
+
+/** Uniqueness predicate used before calling addConcept. */
+function isLocalNameTaken(schemeBase: string, localName: string, existingIris: string[]): boolean {
+  const iri = composeConceptIri(schemeBase, localName)
+  return existingIris.includes(iri)
+}
+
+const LOCAL_NAME_RE = /^[A-Za-z0-9_-]+$/
+
+describe('conceptLocalName', () => {
+  it('derives a lowerCamelCase identifier from a multi-word label', () => {
+    expect(conceptLocalName('Cross Reference')).toBe('crossReference')
+    expect(conceptLocalName('Collective Title')).toBe('collectiveTitle')
+    expect(conceptLocalName('Had Derivation')).toBe('hadDerivation')
+  })
+
+  it('lower-cases a single word label', () => {
+    expect(conceptLocalName('Generated')).toBe('generated')
+  })
+
+  it('treats hyphens and underscores as word separators', () => {
+    expect(conceptLocalName('borehole_status-codes')).toBe('boreholeStatusCodes')
+  })
+
+  it('strips characters unsafe in an IRI segment', () => {
+    expect(conceptLocalName('Hazard & Risk (v2)!')).toBe('hazardRiskV2')
+  })
+
+  it('falls back to a default for empty/blank input', () => {
+    expect(conceptLocalName('   ')).toBe('concept')
+    expect(conceptLocalName('@@@')).toBe('concept')
+    expect(conceptLocalName('')).toBe('concept')
+  })
+
+  it('produces an identifier matching the validation pattern', () => {
+    expect(LOCAL_NAME_RE.test(conceptLocalName('Cross Reference'))).toBe(true)
+    expect(LOCAL_NAME_RE.test(conceptLocalName('Hazard & Risk!'))).toBe(true)
+  })
+})
+
+describe('composeConceptIri', () => {
+  it('appends to a scheme IRI with a trailing slash', () => {
+    expect(composeConceptIri('https://pid.geoscience.gov.au/def/voc/ga/assoctype/', 'crossReference'))
+      .toBe('https://pid.geoscience.gov.au/def/voc/ga/assoctype/crossReference')
+  })
+
+  it('ensures a trailing slash when the scheme IRI has none', () => {
+    expect(composeConceptIri('https://example.org/def/voc/scheme', 'crossReference'))
+      .toBe('https://example.org/def/voc/scheme/crossReference')
+  })
+
+  it('respects an existing hash separator', () => {
+    expect(composeConceptIri('https://example.org/def/voc/scheme#', 'crossReference'))
+      .toBe('https://example.org/def/voc/scheme#crossReference')
+  })
+
+  it('composes label → identifier → IRI end to end', () => {
+    const base = 'https://example.org/def/voc/scheme/'
+    const localName = conceptLocalName('Cross Reference')
+    expect(composeConceptIri(base, localName))
+      .toBe('https://example.org/def/voc/scheme/crossReference')
+  })
+})
+
+describe('isLocalNameTaken (uniqueness predicate)', () => {
+  const base = 'https://example.org/def/voc/scheme/'
+  const existing = [
+    'https://example.org/def/voc/scheme/crossReference',
+    'https://example.org/def/voc/scheme/collectiveTitle',
+  ]
+
+  it('flags a clash with an existing concept IRI', () => {
+    expect(isLocalNameTaken(base, 'crossReference', existing)).toBe(true)
+  })
+
+  it('allows an unused identifier', () => {
+    expect(isLocalNameTaken(base, 'hadDerivation', existing)).toBe(false)
+  })
+
+  it('treats the base trailing slash consistently', () => {
+    // Same logical IRI even though base lacks the trailing slash.
+    expect(isLocalNameTaken('https://example.org/def/voc/scheme', 'crossReference', existing)).toBe(true)
+  })
+})


### PR DESCRIPTION
## What
Adds a **New concept** modal so a concept's IRI is derived from a human-readable **identifier** (defaulting to a lowerCamelCase slug of the preferred label, e.g. `Cross Reference` → `crossReference`) instead of the `new-concept-N` placeholder. Once a concept exists, its **IRI is read-only** in the UI (copy-only) — changing it is a manual TTL operation, since renaming would break back-links (broader/narrower, hasTopConcept, etc.).

## Changes
- `composables/useVocabCreate.ts` — `conceptLocalName(label)` helper (label → lowerCamelCase).
- `components/CreateConceptModal.vue` (new) — Preferred label + Identifier (auto-slugged, editable) + live IRI preview.
- `pages/scheme.vue` — `+ Add` opens the modal; create handler checks IRI collisions within the scheme; removes the rename wiring.
- `components/ConceptForm.vue`, `InlineEditTable.vue`, `ConceptSpreadsheet.vue` — IRI shown read-only with copy-to-clipboard; rename affordance removed.
- `tests/unit/concept-create.test.ts` (new) — identifier/IRI derivation + uniqueness.

## Tests
438 unit/component tests pass (+13). Typecheck: zero new errors (41 = pre-existing baseline, stash-compared).