### PR TITLE
fix: bind workspace vocab context to the open vocab so saves target the right branch

### DIFF
--- a/web/app/pages/scheme.vue
+++ b/web/app/pages/scheme.vue
@@ -806,6 +806,23 @@ const editErrorModal = ref(false)
 const editErrorMessage = ref('')
 const editErrorPath = ref('')
 
+// Keep the workspace vocab context bound to the vocab currently open in the editor,
+// independent of edit-mode entry. Without this, navigating directly to a vocab while a
+// *different* vocab is left in the workspace state saves to the wrong edit branch (the
+// stale workspace vocabSlug). The enter-edit watcher below also binds it, but its guards
+// (not-yet-editing, definitions loaded) can be skipped by load-order races; this
+// dedicated, immediate watcher re-binds as soon as the vocab list and workspace
+// definitions are available, so the edit branch is correct before any save.
+watch(
+  [vocabSlugForEditor, () => workspace.activeWorkspace.value],
+  ([slug, ws]) => {
+    if (ws && slug && workspace.activeVocabSlug.value !== slug) {
+      workspace.selectVocab(slug)
+    }
+  },
+  { immediate: true },
+)
+
 // Auto-enter edit mode when authenticated + vocab ready.
 // On page load auth token and vocab metadata may not be available yet, so watch all three.
 watch([editView, authToken, vocabSlugForEditor], async ([view]) => {

--- a/web/tests/unit/workspace.test.ts
+++ b/web/tests/unit/workspace.test.ts
@@ -237,3 +237,39 @@ describe('workspace label', () => {
     expect(deriveLabel(null, definitions)).toBeNull()
   })
 })
+
+describe('vocab context sync (save targets the open vocab branch)', () => {
+  // Mirrors scheme.vue's dedicated sync watcher: re-bind the workspace vocabSlug to
+  // the vocab open in the editor whenever (definitions loaded) the open vocab is known
+  // and differs. Guards against saving to a stale/different vocab's edit branch.
+  function syncedVocabSlug(o: { wsLoaded: boolean; openSlug: string | undefined; currentSlug: string | null }): string | null {
+    if (o.wsLoaded && o.openSlug && o.currentSlug !== o.openSlug) return o.openSlug
+    return o.currentSlug
+  }
+  function editBranch(wsSlug: string, vocabSlug: string | null): string {
+    return vocabSlug ? `edit/${wsSlug}/${vocabSlug}` : wsSlug
+  }
+
+  it('re-binds to the open vocab when a different one is left stale (the bug)', () => {
+    const next = syncedVocabSlug({ wsLoaded: true, openSlug: 'AssociationType', currentSlug: 'E2EGIFVocabulary' })
+    expect(next).toBe('AssociationType')
+    // the save must target the open vocab's branch, not the stale one
+    expect(editBranch('develop', next)).toBe('edit/develop/AssociationType')
+  })
+
+  it('leaves the context unchanged when it already matches', () => {
+    expect(syncedVocabSlug({ wsLoaded: true, openSlug: 'AssociationType', currentSlug: 'AssociationType' }))
+      .toBe('AssociationType')
+  })
+
+  it('does not clobber the context when the open vocab is not yet indexed (new vocab)', () => {
+    // create-vocab flow sets vocabSlug itself; the open vocab may not be in the index yet
+    expect(syncedVocabSlug({ wsLoaded: true, openSlug: undefined, currentSlug: 'MyNewVocab' }))
+      .toBe('MyNewVocab')
+  })
+
+  it('waits for workspace definitions before binding', () => {
+    expect(syncedVocabSlug({ wsLoaded: false, openSlug: 'AssociationType', currentSlug: 'E2EGIFVocabulary' }))
+      .toBe('E2EGIFVocabulary')
+  })
+})


### PR DESCRIPTION
## Bug
Navigating **directly** to a vocabulary's page (not via the workspace dashboard) while a **different** vocab was left in the workspace state would save to the *wrong* edit branch. `ensureEditBranch()` derives the branch from `workspace.vocabSlug`; the enter-edit watcher's re-bind is guarded on (not-yet-editing + definitions loaded) and could be skipped by load-order races, leaving the stale vocab's branch as the save target.

Found during end-to-end walkthrough recording: an edit to *AssociationType* was committed to `edit/develop/E2EGIFVocabulary` (a stale vocab from an earlier test).

## Fix
Add a dedicated, **immediate** watcher in `scheme.vue` that re-binds the workspace `vocabSlug` to the vocab open in the editor as soon as the vocab list and workspace definitions are available — independent of edit-mode entry — so the edit branch is correct before any save. Does not clobber the context for a not-yet-indexed new vocab (the create-vocab flow sets it).

## Tests
447 unit/component tests pass (+4 covering the sync contract). Typecheck: zero new errors (41 = pre-existing baseline).