### PR TITLE
fix: review modal title shows vocab name, not [object Object]

### DIFF
--- a/web/app/pages/scheme.vue
+++ b/web/app/pages/scheme.vue
@@ -404,7 +404,10 @@ const promotionExistingPR = computed(() => {
 
 /** Context-aware modal title */
 const reviewModalTitle = computed(() => {
-  const vocabName = editModeTitle.value ?? displayScheme.value?.prefLabel ?? 'Changes'
+  // displayScheme.prefLabel is a LangMap, not a string — run it through getLabel so
+  // the title doesn't render "[object Object]" when editModeTitle is empty (e.g. the
+  // merged/approved review state).
+  const vocabName = editModeTitle.value || getLabel(displayScheme.value?.prefLabel) || 'Changes'
   const wsLabel = workspace.activeWorkspace.value?.label ?? 'Staging'
   const isPending = promotionLayer.value === 'pending'
 


### PR DESCRIPTION
When approving a per-vocab review, the modal header rendered **"Review [object Object] Changes"**: `reviewModalTitle` fell back to `displayScheme.prefLabel` (a `LangMap` object) when `editModeTitle` was empty. Wrapped it in `getLabel()` — the same pattern the page heading (scheme.vue:1582) already uses. Found during walkthrough recording of the approval flow.