### PR TITLE
fix: changed-in-staging compares file content, not the diverged commit graph

### DIFF
--- a/web/app/composables/usePromotion.ts
+++ b/web/app/composables/usePromotion.ts
@@ -465,27 +465,48 @@ export function usePromotion(
     if (!ws || !owner || !repo || !token.value) return []
 
     try {
-      const [compareData, metadata] = await Promise.all([
-        githubFetch<{ files?: Array<{ filename: string; status: string }> }>(
-          `https://api.github.com/repos/${owner}/${repo}/compare/${encodeURIComponent(ws.refreshFrom)}...${encodeURIComponent(ws.slug)}`,
-        ),
+      // Compare actual file CONTENT (git blob SHA) between the workspace branch
+      // (e.g. develop) and what it publishes to (e.g. master), NOT the commit-graph
+      // `compare` diff. When the two branches diverge, `compare/base...head` lists
+      // every file touched on head since the (stale) merge base — so an already
+      // published vocab keeps showing as "changed in staging" even though its content
+      // is byte-identical on both branches. Diffing blob SHAs reports only genuine
+      // content differences, so published vocabs drop off correctly.
+      const treeUrl = (ref: string) =>
+        `https://api.github.com/repos/${owner}/${repo}/git/trees/${encodeURIComponent(ref)}?recursive=1`
+      const [baseTree, headTree, metadata] = await Promise.all([
+        githubFetch<{ tree?: Array<{ path: string; type: string; sha: string }> }>(treeUrl(ws.refreshFrom)),
+        githubFetch<{ tree?: Array<{ path: string; type: string; sha: string }> }>(treeUrl(ws.slug)),
         fetchVocabMetadata().catch(() => []),
       ])
-      if (!compareData?.files) return []
+      if (!headTree?.tree || !baseTree?.tree) return []
 
       const { githubVocabPath } = useRuntimeConfig().public
       const vocabPrefix = ((githubVocabPath as string) || '').replace(/^\/+|\/+$/g, '')
+      const isVocab = (p: string) => p.endsWith('.ttl') && (!vocabPrefix || p.startsWith(vocabPrefix + '/'))
+      const shaMap = (tree: Array<{ path: string; type: string; sha: string }>) =>
+        new Map(tree.filter(t => t.type === 'blob' && isVocab(t.path)).map(t => [t.path, t.sha]))
+      const baseShas = shaMap(baseTree.tree)
+      const headShas = shaMap(headTree.tree)
 
-      // Build slug → label lookup from vocab metadata
       const labelMap = new Map(metadata.map(v => [v.slug, v.prefLabel]))
+      const slugOf = (path: string) => (path.split('/').pop() ?? path).replace(/\.ttl$/, '')
+      const changed: { slug: string; label: string; status: string }[] = []
 
-      return compareData.files
-        .filter(f => f.filename.endsWith('.ttl') && (!vocabPrefix || f.filename.startsWith(vocabPrefix + '/')))
-        .map(f => {
-          const filename = f.filename.split('/').pop() ?? f.filename
-          const slug = filename.replace(/\.ttl$/, '')
-          return { slug, label: labelMap.get(slug) ?? slug, status: f.status }
-        })
+      // Added / modified: present on head with a different (or absent) base blob SHA.
+      for (const [path, sha] of headShas) {
+        const baseSha = baseShas.get(path)
+        if (baseSha === sha) continue // identical content → already in sync, not "changed"
+        const slug = slugOf(path)
+        changed.push({ slug, label: labelMap.get(slug) ?? slug, status: baseSha ? 'modified' : 'added' })
+      }
+      // Removed: present on base but gone from head.
+      for (const path of baseShas.keys()) {
+        if (headShas.has(path)) continue
+        const slug = slugOf(path)
+        changed.push({ slug, label: labelMap.get(slug) ?? slug, status: 'removed' })
+      }
+      return changed
     } catch {
       return []
     }

--- a/web/tests/unit/workspace.test.ts
+++ b/web/tests/unit/workspace.test.ts
@@ -273,3 +273,41 @@ describe('vocab context sync (save targets the open vocab branch)', () => {
       .toBe('E2EGIFVocabulary')
   })
 })
+
+describe('changed-in-staging by content (blob SHA), not commit graph', () => {
+  // Mirrors usePromotion.fetchChangedVocabs: diff the per-file blob SHAs of the
+  // workspace branch (head, e.g. develop) against what it publishes to (base, e.g.
+  // master). A vocab is "changed in staging" only when its content actually differs.
+  // The old code trusted compare/base...head .files, which lists files touched on
+  // head since the merge base — so it falsely flagged already-published vocabs once
+  // the branches diverged. This contract prevents that.
+  function changedVocabs(base: Record<string, string>, head: Record<string, string>) {
+    const out: { slug: string; status: string }[] = []
+    for (const [path, sha] of Object.entries(head)) {
+      if (base[path] === sha) continue
+      out.push({ slug: path, status: path in base ? 'modified' : 'added' })
+    }
+    for (const path of Object.keys(base)) {
+      if (!(path in head)) out.push({ slug: path, status: 'removed' })
+    }
+    return out
+  }
+
+  it('does NOT flag an already-published vocab (identical SHA) even on diverged branches', () => {
+    // both branches hold the published edit -> same blob SHA -> not "changed"
+    expect(changedVocabs({ 'a.ttl': 'sha1', 'b.ttl': 'shaB' }, { 'a.ttl': 'sha1', 'b.ttl': 'shaB' }))
+      .toEqual([])
+  })
+
+  it('flags a genuinely modified vocab (SHA differs)', () => {
+    expect(changedVocabs({ 'a.ttl': 'sha1' }, { 'a.ttl': 'sha2' }))
+      .toEqual([{ slug: 'a.ttl', status: 'modified' }])
+  })
+
+  it('flags added and removed vocabs', () => {
+    const r = changedVocabs({ 'a.ttl': 's', 'gone.ttl': 'g' }, { 'a.ttl': 's', 'new.ttl': 'n' })
+    expect(r).toContainEqual({ slug: 'new.ttl', status: 'added' })
+    expect(r).toContainEqual({ slug: 'gone.ttl', status: 'removed' })
+    expect(r).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## Bug
A vocabulary that has already been published keeps showing as **"changed in staging"** in the workspace once the workspace branch (e.g. `develop`) and its publish target (e.g. `master`) have diverged.

`fetchChangedVocabs` used `compare/<refreshFrom>...<workspace>` and trusted `.files` — the commit-graph diff, which lists every file touched on the workspace branch *since the merge base*. With a stale merge base, an already-published vocab is still "ahead" by its commit even though its file content is byte-identical on both branches, so it never clears.

Confirmed live: `Borehole_Material_Boreholes.ttl` had identical blob SHA on `develop` and `master` (published), yet `compare/master...develop` still listed it.

## Fix
Diff the per-file **git blob SHAs** of the two branch trees (`git/trees/<ref>?recursive=1`) instead. Only vocabs whose content genuinely differs are reported (added / modified / removed). Published vocabs drop off correctly regardless of commit divergence.

## Tests
450 unit/component pass (+3 for the content-diff contract). Typecheck: 0 new errors (41 baseline).