### PR TITLE
fix: per-subject save includes reciprocal edits (hasTopConcept / narrower)

### DIFF
--- a/web/app/composables/useEditMode.ts
+++ b/web/app/composables/useEditMode.ts
@@ -1031,15 +1031,23 @@ export function useEditMode(
     }
 
     const { added, removed } = computeDiff()
-    const modifiedSubjects = subjectIri
-      ? new Set([subjectIri])
-      : getModifiedSubjects(added, removed)
-
-    // Also include subjects affected indirectly (e.g. broader/narrower sync)
-    if (!subjectIri) {
-      // Re-compute to catch all
-      const allModified = getModifiedSubjects(added, removed)
-      for (const s of allModified) modifiedSubjects.add(s)
+    const modifiedSubjects = new Set<string>()
+    if (subjectIri) {
+      modifiedSubjects.add(subjectIri)
+      // Include subjects modified only as a reciprocal side-effect of saving this one —
+      // e.g. the scheme's skos:hasTopConcept, or a parent concept's skos:narrower, that
+      // point AT this subject. They are part of the same logical change, so a per-subject
+      // save must include them too. Otherwise the reciprocal edit is orphaned: it stays
+      // "unsaved" after the concept is saved, and the branch gets an inconsistent file
+      // (concept has topConceptOf but the scheme lacks the matching hasTopConcept).
+      for (const q of [...added, ...removed]) {
+        if (q.object.termType === 'NamedNode' && q.object.value === subjectIri) {
+          modifiedSubjects.add(q.subject.value)
+        }
+      }
+    } else {
+      // Full save: every modified subject (already covers indirect broader/narrower sync).
+      for (const s of getModifiedSubjects(added, removed)) modifiedSubjects.add(s)
     }
 
     // Include deleted subjects (exist in original but have zero quads in current store).

--- a/web/tests/unit/serialize-with-patch.test.ts
+++ b/web/tests/unit/serialize-with-patch.test.ts
@@ -51,9 +51,19 @@ function serializeWithPatch(
   subjectIri?: string,
 ): string {
   const { added, removed } = computeQuadDiff(originalStore, store)
-  const modifiedSubjects = subjectIri
-    ? new Set([subjectIri])
-    : getModifiedSubjects(added, removed)
+  const modifiedSubjects = new Set<string>()
+  if (subjectIri) {
+    modifiedSubjects.add(subjectIri)
+    // Include subjects modified only as a reciprocal side-effect (scheme hasTopConcept,
+    // parent narrower) that point AT this subject — part of the same logical change.
+    for (const q of [...added, ...removed]) {
+      if (q.object.termType === 'NamedNode' && q.object.value === subjectIri) {
+        modifiedSubjects.add(q.subject.value)
+      }
+    }
+  } else {
+    for (const s of getModifiedSubjects(added, removed)) modifiedSubjects.add(s)
+  }
 
   const patches = new Map<string, string | null>()
   const newBlocks: string[] = []
@@ -304,6 +314,41 @@ describe('serializeWithPatch', () => {
 
       expect(result).toContain('Changed A')
       expect(result).not.toContain('cs:c')
+    })
+
+    // Regression: adding a new TOP concept dirties two subjects (the concept + the
+    // scheme's hasTopConcept). A per-subject save must carry the scheme's reciprocal
+    // edit too, or it's orphaned as "unsaved" and the file becomes inconsistent.
+    it('includes the scheme hasTopConcept reciprocal when saving a new top concept', () => {
+      const { store, originalStore, parsedTTL } = makeContext()
+      const top = `${SCHEME}top`
+      store.addQuad(namedNode(top), namedNode(`${RDF}type`), namedNode(`${SKOS}Concept`), defaultGraph())
+      store.addQuad(namedNode(top), namedNode(`${SKOS}prefLabel`), literal('Top', 'en'), defaultGraph())
+      store.addQuad(namedNode(top), namedNode(`${SKOS}inScheme`), namedNode(SCHEME), defaultGraph())
+      store.addQuad(namedNode(top), namedNode(`${SKOS}topConceptOf`), namedNode(SCHEME), defaultGraph())
+      // reciprocal on the scheme subject
+      store.addQuad(namedNode(SCHEME), namedNode(`${SKOS}hasTopConcept`), namedNode(top), defaultGraph())
+
+      const result = serializeWithPatch(store, originalStore, parsedTTL, PREFIXES, top)
+
+      const reparsed = parseTTL(result)
+      expect(reparsed.getQuads(top, `${RDF}type`, `${SKOS}Concept`, null)).toHaveLength(1)
+      // the scheme's reciprocal link is saved alongside the concept (the bug: it wasn't)
+      expect(reparsed.getQuads(SCHEME, `${SKOS}hasTopConcept`, top, null)).toHaveLength(1)
+    })
+
+    it('includes a parent concept narrower reciprocal when saving a child concept', () => {
+      const { store, originalStore, parsedTTL } = makeContext()
+      const child = `${SCHEME}child`
+      store.addQuad(namedNode(child), namedNode(`${RDF}type`), namedNode(`${SKOS}Concept`), defaultGraph())
+      store.addQuad(namedNode(child), namedNode(`${SKOS}prefLabel`), literal('Child', 'en'), defaultGraph())
+      store.addQuad(namedNode(child), namedNode(`${SKOS}broader`), namedNode(CONCEPT_A), defaultGraph())
+      store.addQuad(namedNode(CONCEPT_A), namedNode(`${SKOS}narrower`), namedNode(child), defaultGraph())
+
+      const result = serializeWithPatch(store, originalStore, parsedTTL, PREFIXES, child)
+
+      const reparsed = parseTTL(result)
+      expect(reparsed.getQuads(CONCEPT_A, `${SKOS}narrower`, child, null)).toHaveLength(1)
     })
   })
 


### PR DESCRIPTION
## Bug
After adding a **new concept** to an existing vocab and pressing **Save**, the UI still shows the vocabulary as having **Unsaved** changes (while the concept shows under **Saved**). The edit branch is created, but the scheme's reciprocal edit is stuck.

Adding a top concept dirties **two** subjects — the concept, and the scheme's `skos:hasTopConcept` (or a parent's `skos:narrower` for a child). `serializeWithPatch` only added indirectly-affected subjects on the *full-save* path; the per-subject save (`saveSubject`, used by the Save modal at `scheme.vue:975`) patched only the concept block. So the scheme's reciprocal edit was never written and never cleared — left as "Unsaved" forever, and the saved TTL was inconsistent (concept has `topConceptOf` but scheme lacks `hasTopConcept`).

## Fix
In the per-subject serialization path, also include any subject modified as a **reciprocal side-effect** — a changed quad whose object is the subject being saved (e.g. `scheme hasTopConcept <thisConcept>`, `parent narrower <thisConcept>`). They're part of the same logical change and must be saved together.

## Tests
452 unit/component pass (+2 regression tests: top-concept reciprocal, broader/narrower reciprocal). Typecheck: 0 new errors.