### PR TITLE
feat: workspace vocab list reads branch ttls; add staged-change discard

### DIFF
--- a/web/app/composables/usePromotion.ts
+++ b/web/app/composables/usePromotion.ts
@@ -93,6 +93,31 @@ export function buildPRBody(changes: SubjectChange[]): string {
   return lines.join('\n')
 }
 
+/**
+ * Decide how to discard one vocab's staged change, given its status and what
+ * exists on the workspace branch (headSha) / publish target (baseContent).
+ * Pure — the composable executes the returned op against the contents API.
+ */
+export type DiscardOp =
+  | { kind: 'delete'; sha: string }
+  | { kind: 'restore'; content: string; sha?: string }
+  | { kind: 'noop' }
+  | { kind: 'error'; reason: string }
+
+export function planDiscard(
+  status: string,
+  headSha: string | null,
+  baseContent: string | null,
+): DiscardOp {
+  if (status === 'added') {
+    // Never published — remove the file outright (nothing to restore from base)
+    return headSha ? { kind: 'delete', sha: headSha } : { kind: 'noop' }
+  }
+  // modified / removed — restore the base branch content
+  if (!baseContent) return { kind: 'error', reason: 'missing-base' }
+  return { kind: 'restore', content: baseContent, sha: headSha ?? undefined }
+}
+
 // ============================================================================
 // Composable
 // ============================================================================
@@ -512,6 +537,87 @@ export function usePromotion(
     }
   }
 
+  /**
+   * Discard one vocabulary's staged change: reset the workspace branch copy of
+   * the vocab TTL to match the publish target (refreshFrom). This is the only
+   * unwind path for a vocab whose edit branch is already gone (e.g. a new
+   * vocab approved into staging whose publish PR was then rejected).
+   *
+   *   - added    → delete the TTL from the workspace branch (+ drop any
+   *                leftover edit branch so the vocab can't leak back)
+   *   - modified → overwrite the branch TTL with the base branch content
+   *   - removed  → restore the TTL from the base branch
+   */
+  async function discardVocabChange(v: { slug: string; status: string }): Promise<boolean> {
+    const ws = workspace.activeWorkspace.value
+    if (!ws || !owner || !repo || !token.value) {
+      error.value = 'Not authenticated'
+      return false
+    }
+    error.value = null
+
+    const { githubVocabPath } = useRuntimeConfig().public
+    const vocabPrefix = ((githubVocabPath as string) || 'data/vocabs').replace(/^\/+|\/+$/g, '')
+    const path = `${vocabPrefix}/${v.slug}.ttl`
+    const contentsUrl = (ref?: string) =>
+      `https://api.github.com/repos/${owner}/${repo}/contents/${path}${ref ? `?ref=${encodeURIComponent(ref)}` : ''}`
+
+    try {
+      // Current file on the workspace branch — sha is required for update/delete.
+      const head = await githubFetch<{ sha: string }>(contentsUrl(ws.slug))
+      // Base content only needed for restore ops. The contents API returns
+      // base64, which PUT accepts as-is — no decode/re-encode needed.
+      const base = v.status === 'added'
+        ? null
+        : await githubFetch<{ content?: string }>(contentsUrl(ws.refreshFrom))
+
+      const op = planDiscard(v.status, head?.sha ?? null, base?.content ?? null)
+
+      if (op.kind === 'error') {
+        error.value = `Could not read ${v.slug} from ${ws.refreshFrom}`
+        return false
+      }
+
+      if (op.kind === 'delete') {
+        const res = await githubFetch(contentsUrl(), {
+          method: 'DELETE',
+          body: JSON.stringify({
+            message: `revert: remove ${v.slug} (discard staged addition)`,
+            sha: op.sha,
+            branch: ws.slug,
+          }),
+        })
+        if (!res) {
+          error.value = lastFetchError.value?.githubMessage ?? `Failed to remove ${v.slug}`
+          return false
+        }
+      } else if (op.kind === 'restore') {
+        const res = await githubFetch(contentsUrl(), {
+          method: 'PUT',
+          body: JSON.stringify({
+            message: `revert: restore ${v.slug} to match ${ws.refreshFrom} (discard staged change)`,
+            content: op.content.replace(/\s/g, ''),
+            branch: ws.slug,
+            ...(op.sha ? { sha: op.sha } : {}),
+          }),
+        })
+        if (!res) {
+          error.value = lastFetchError.value?.githubMessage ?? `Failed to restore ${v.slug}`
+          return false
+        }
+      }
+
+      if (v.status === 'added') {
+        // Drop the ephemeral edit branch so the discarded vocab can't leak back.
+        await workspace.deleteBranch(`edit/${ws.slug}/${v.slug}`)
+      }
+      return true
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : 'Something went wrong. Please try again.'
+      return false
+    }
+  }
+
   /** Generate a default review title for a given layer */
   function generateTitle(layer: 'pending' | 'approved'): string {
     const ws = workspace.activeWorkspace.value
@@ -565,5 +671,6 @@ export function usePromotion(
     generateTitle,
     getBranches,
     fetchChangedVocabs,
+    discardVocabChange,
   }
 }

--- a/web/app/composables/useWorkspaceVocabs.ts
+++ b/web/app/composables/useWorkspaceVocabs.ts
@@ -1,0 +1,166 @@
+/**
+ * useWorkspaceVocabs composable
+ *
+ * Builds the workspace vocabulary list from what actually exists on the work
+ * branches, not just the deployed index. The generated index
+ * (/export/system/vocabularies/index.json) is only rebuilt when the deploy
+ * branch is reprocessed, so on its own it:
+ *   - misses vocabs approved into the workspace branch but not yet published
+ *     and deployed (invisible, unclickable "ghosts"), and
+ *   - still lists vocabs that were removed on the workspace branch.
+ *
+ * Sources merged, in order:
+ *   1. Generated index — full metadata for published + deployed vocabs.
+ *   2. Vocab TTLs on the workspace branch (e.g. develop) — vocabs not in the
+ *      index get a stub entry parsed from the TTL; index entries whose TTL is
+ *      gone from the branch are dropped (removed in staging).
+ *   3. Vocab TTLs on this workspace's edit branches (edit/<ws>/<slug>) —
+ *      vocabs created but not yet approved into the workspace branch.
+ *
+ * Stubs are injected into useVocabData's caches (injectVocab) so /scheme can
+ * resolve them when the user clicks through.
+ */
+
+import { createGithubFetch, type GithubFetchError } from '~/utils/github-fetch'
+import { fetchVocabMetadata, injectVocab, type VocabMetadata } from '~/composables/useVocabData'
+import { parseVocabTtlMeta } from '~/utils/vocab-ttl-meta'
+
+export interface WorkspaceVocabList {
+  vocabs: VocabMetadata[]
+  /** Slugs that exist on work branches but not in the published index */
+  unpublished: Set<string>
+}
+
+/**
+ * Pure merge plan: which index entries survive (their TTL is still on the
+ * branch), which branch slugs need stubs (not in the index), and which index
+ * entries are dropped (TTL removed on the branch).
+ */
+export function planVocabMerge(
+  index: VocabMetadata[],
+  branchSlugs: string[],
+): { published: VocabMetadata[]; needStubs: string[]; dropped: string[] } {
+  const branchSet = new Set(branchSlugs)
+  const indexSlugs = new Set(index.map(v => v.slug))
+  return {
+    published: index.filter(v => branchSet.has(v.slug)),
+    needStubs: branchSlugs.filter(s => !indexSlugs.has(s)),
+    dropped: index.filter(v => !branchSet.has(v.slug)).map(v => v.slug),
+  }
+}
+
+/** UTF-8 safe base64 decode (GitHub contents API wraps base64 with newlines). */
+function fromBase64(b64: string): string {
+  const clean = b64.replace(/\s/g, '')
+  if (typeof atob === 'function') {
+    return decodeURIComponent(escape(atob(clean)))
+  }
+  return Buffer.from(clean, 'base64').toString('utf-8')
+}
+
+// Stub cache keyed by git blob SHA — content-addressed, so entries never go
+// stale and survive across refetches/watch re-triggers.
+const stubCache = new Map<string, VocabMetadata>()
+
+export function useWorkspaceVocabs(workspace: ReturnType<typeof useWorkspace>) {
+  const { token } = useGitHubAuth()
+  const { githubVocabPath } = useRuntimeConfig().public
+  const { owner, repo } = workspace
+
+  const lastError = ref<GithubFetchError | null>(null)
+  const githubFetch = createGithubFetch(token, 'workspace-vocabs', lastError)
+
+  const vocabPath = ((githubVocabPath as string) || 'data/vocabs').replace(/^\/+|\/+$/g, '')
+  const slugOf = (path: string) => (path.split('/').pop() ?? path).replace(/\.ttl$/, '')
+
+  /** Fetch a TTL blob and parse it into a stub VocabMetadata (cached by blob SHA). */
+  async function loadStub(path: string, ref: string, blobSha: string | null): Promise<VocabMetadata | null> {
+    if (blobSha) {
+      const cached = stubCache.get(blobSha)
+      if (cached) return cached
+    }
+    const file = await githubFetch<{ sha: string; content?: string }>(
+      `https://api.github.com/repos/${owner}/${repo}/contents/${path}?ref=${encodeURIComponent(ref)}`,
+    )
+    if (!file?.content) return null
+    const meta = parseVocabTtlMeta(fromBase64(file.content))
+    if (!meta?.iri) {
+      console.warn(`[workspace-vocabs] Could not parse ConceptScheme from ${path}@${ref}`)
+      return null
+    }
+    const slug = slugOf(path)
+    const stub: VocabMetadata = {
+      iri: meta.iri,
+      slug,
+      prefLabel: meta.prefLabel || slug,
+      definition: meta.definition,
+      conceptCount: meta.conceptCount,
+    }
+    stubCache.set(file.sha, stub)
+    return stub
+  }
+
+  /**
+   * Build the workspace vocab list. Falls back to the plain index when the
+   * workspace/GitHub context is unavailable or a call fails.
+   */
+  async function fetchWorkspaceVocabs(): Promise<WorkspaceVocabList> {
+    const index = await fetchVocabMetadata().catch(() => [] as VocabMetadata[])
+    const ws = workspace.activeWorkspace.value
+    if (!ws || !owner || !repo || !token.value) {
+      return { vocabs: index, unpublished: new Set() }
+    }
+
+    try {
+      // 2. TTLs on the workspace branch
+      const tree = await githubFetch<{ tree?: Array<{ path: string; type: string; sha: string }> }>(
+        `https://api.github.com/repos/${owner}/${repo}/git/trees/${encodeURIComponent(ws.slug)}?recursive=1`,
+      )
+      if (!tree?.tree) return { vocabs: index, unpublished: new Set() }
+
+      const branchBlobs = tree.tree.filter(
+        t => t.type === 'blob' && t.path.endsWith('.ttl') && t.path.startsWith(`${vocabPath}/`),
+      )
+      const { published, needStubs } = planVocabMerge(index, branchBlobs.map(t => slugOf(t.path)))
+
+      const unpublished = new Set<string>()
+      const stubs: VocabMetadata[] = []
+      for (const t of branchBlobs) {
+        const slug = slugOf(t.path)
+        if (!needStubs.includes(slug)) continue
+        const stub = await loadStub(t.path, ws.slug, t.sha)
+        if (stub) {
+          stubs.push(stub)
+          unpublished.add(slug)
+        }
+      }
+
+      // 3. Vocabs that exist only on an edit branch (created, not yet approved)
+      const editPrefix = `edit/${ws.slug}/`
+      const seen = new Set([...published, ...stubs].map(v => v.slug))
+      for (const b of workspace.branches.value) {
+        if (!b.name.startsWith(editPrefix)) continue
+        const slug = b.name.slice(editPrefix.length)
+        if (!slug || seen.has(slug)) continue
+        const stub = await loadStub(`${vocabPath}/${slug}.ttl`, b.name, null)
+        if (stub) {
+          stubs.push(stub)
+          seen.add(slug)
+          unpublished.add(slug)
+        }
+      }
+
+      // Make stubs resolvable by useScheme/useShare when the user clicks through.
+      for (const s of stubs) injectVocab(s)
+
+      return { vocabs: [...published, ...stubs], unpublished }
+    } catch {
+      return { vocabs: index, unpublished: new Set() }
+    }
+  }
+
+  return {
+    fetchWorkspaceVocabs,
+    lastError: readonly(lastError),
+  }
+}

--- a/web/app/pages/workspace.vue
+++ b/web/app/pages/workspace.vue
@@ -11,6 +11,9 @@ const vocabs = ref<VocabMetadata[]>([])
 const vocabsLoading = ref(false)
 const selectingVocab = ref<string | null>(null)
 const selectError = ref<string | null>(null)
+// Slugs on work branches but not yet in the published index (shown as "new")
+const unpublishedSlugs = ref<Set<string>>(new Set())
+const workspaceVocabs = useWorkspaceVocabs(workspace)
 
 // Redirect to home if not authenticated (wait for auth to finish initializing)
 watch([isAuthenticated, authLoading], ([authenticated, isLoading]) => {
@@ -29,19 +32,34 @@ watch(() => workspace.isEnabled.value, async (enabled) => {
   }
 }, { immediate: true })
 
-// Load vocab list when a workspace is selected
-watch(() => workspace.state.value?.workspaceSlug, async (slug) => {
-  if (slug) {
-    vocabsLoading.value = true
+// Load vocab list when a workspace is selected. Re-runs when branches load so
+// vocabs that exist only on work branches (not yet in the published index)
+// appear too — see useWorkspaceVocabs.
+async function loadVocabList() {
+  // Only flash the spinner on first load — refreshes swap in place
+  if (!vocabs.value.length) vocabsLoading.value = true
+  try {
+    const res = await workspaceVocabs.fetchWorkspaceVocabs()
+    vocabs.value = res.vocabs
+    unpublishedSlugs.value = res.unpublished
+  } catch {
     try {
       vocabs.value = await fetchVocabMetadata()
     } catch {
       vocabs.value = []
-    } finally {
-      vocabsLoading.value = false
     }
+  } finally {
+    vocabsLoading.value = false
   }
-}, { immediate: true })
+}
+
+watch(
+  [() => workspace.state.value?.workspaceSlug, () => workspace.branches.value],
+  async ([slug]) => {
+    if (slug) await loadVocabList()
+  },
+  { immediate: true },
+)
 
 function handleSelectWorkspace(slug: string) {
   workspace.selectWorkspace(slug)
@@ -113,12 +131,72 @@ const vocabIriMap = computed(() => {
   return map
 })
 
-function navigateToVocab(slug: string) {
-  const iri = vocabIriMap.value.get(slug)
-  if (iri) {
-    workspace.selectVocab(slug)
-    navigateTo({ path: '/scheme', query: { uri: iri } })
+function navigateToVocab(v: { slug: string; label: string; status: string }) {
+  if (v.status === 'removed') {
+    selectError.value = `"${v.label}" was removed in staging — use Discard to restore it from the published version.`
+    return
   }
+  const iri = vocabIriMap.value.get(v.slug)
+  if (!iri) {
+    selectError.value = `"${v.label}" could not be opened — its file was not found on the workspace branch.`
+    return
+  }
+  workspace.selectVocab(v.slug)
+  navigateTo({ path: '/scheme', query: { uri: iri } })
+}
+
+// --- Discard staged change (unwind a vocab on the workspace branch) ---
+
+const discardTarget = ref<{ slug: string; label: string; status: string } | null>(null)
+const discarding = ref(false)
+const discardError = ref<string | null>(null)
+const showDiscardModal = computed({
+  get: () => !!discardTarget.value,
+  set: (open: boolean) => { if (!open) discardTarget.value = null },
+})
+
+function openDiscardModal(v: { slug: string; label: string; status: string }) {
+  discardError.value = null
+  discardTarget.value = v
+}
+
+function closeDiscardModal() {
+  discardTarget.value = null
+}
+
+const discardDescription = computed(() => {
+  const v = discardTarget.value
+  if (!v) return ''
+  const base = workspace.activeWorkspace.value?.refreshFrom ?? 'the published version'
+  if (v.status === 'added') {
+    return `This permanently removes "${v.label}" from the ${wsLabel.value} workspace. It has not been published, so it will be gone entirely.`
+  }
+  if (v.status === 'removed') {
+    return `This restores "${v.label}" in the ${wsLabel.value} workspace from ${base}.`
+  }
+  return `This resets "${v.label}" in the ${wsLabel.value} workspace to match ${base}, dropping the staged edits.`
+})
+
+async function confirmDiscard() {
+  const v = discardTarget.value
+  if (!v) return
+  discarding.value = true
+  discardError.value = null
+  const ok = await promotion.discardVocabChange(v)
+  discarding.value = false
+  if (!ok) {
+    discardError.value = promotion.error.value ?? 'Failed to discard the change'
+    return
+  }
+  discardTarget.value = null
+  // Clear the vocab selection if the discarded vocab was open
+  if (workspace.activeVocabSlug.value === v.slug && workspace.state.value) {
+    workspace.selectWorkspace(workspace.state.value.workspaceSlug)
+  }
+  // Refresh branches, staged-changes summary and the vocab list
+  await workspace.fetchBranches()
+  changedVocabs.value = await promotion.fetchChangedVocabs()
+  await loadVocabList()
 }
 
 // Per-vocab status derived from branches + changedVocabs
@@ -411,18 +489,30 @@ const workspaceBreadcrumbs = computed(() => {
 
           <!-- Changed vocabs list -->
           <div v-if="changedVocabs.length > 0" class="ml-5.5 space-y-0.5 mb-4">
-            <button
+            <div
               v-for="v in changedVocabs"
               :key="v.slug"
-              type="button"
-              class="w-full flex items-center gap-2 text-sm py-1 px-2 -mx-2 rounded-md hover:bg-muted/50 transition-colors text-left"
-              @click="navigateToVocab(v.slug)"
+              class="flex items-center gap-1 -mx-2"
             >
-              <UIcon name="i-heroicons-book-open" class="size-3.5 shrink-0 text-muted" />
-              <span class="font-medium truncate text-primary hover:underline">{{ v.label }}</span>
-              <span class="text-xs text-muted ml-auto capitalize">{{ v.status }}</span>
-              <UIcon name="i-heroicons-chevron-right" class="size-3 text-muted shrink-0" />
-            </button>
+              <button
+                type="button"
+                class="flex-1 min-w-0 flex items-center gap-2 text-sm py-1 px-2 rounded-md hover:bg-muted/50 transition-colors text-left"
+                @click="navigateToVocab(v)"
+              >
+                <UIcon name="i-heroicons-book-open" class="size-3.5 shrink-0 text-muted" />
+                <span class="font-medium truncate text-primary hover:underline">{{ v.label }}</span>
+                <span class="text-xs text-muted ml-auto capitalize">{{ v.status }}</span>
+                <UIcon name="i-heroicons-chevron-right" class="size-3 text-muted shrink-0" />
+              </button>
+              <UButton
+                icon="i-heroicons-arrow-uturn-left"
+                color="error"
+                variant="ghost"
+                size="xs"
+                :title="`Discard staged change to ${v.label}`"
+                @click="openDiscardModal(v)"
+              />
+            </div>
           </div>
 
           <!-- Promotion actions -->
@@ -505,6 +595,15 @@ const workspaceBreadcrumbs = computed(() => {
             <!-- Status badges -->
             <div class="flex items-center gap-1.5 shrink-0">
               <UBadge
+                v-if="unpublishedSlugs.has(vocab.slug)"
+                color="warning"
+                variant="subtle"
+                size="xs"
+                title="Not yet published — exists only in the workspace"
+              >
+                new
+              </UBadge>
+              <UBadge
                 v-if="vocabStatusMap.get(vocab.slug)?.hasEditBranch"
                 color="primary"
                 variant="subtle"
@@ -579,6 +678,42 @@ const workspaceBreadcrumbs = computed(() => {
             @comment="handlePRComment"
             @close="showReviewModal = false"
           />
+        </template>
+      </UModal>
+
+      <!-- Discard Staged Change Modal -->
+      <UModal v-model:open="showDiscardModal">
+        <template #header>
+          <h3 class="font-semibold">Discard staged change</h3>
+        </template>
+        <template #body>
+          <div class="space-y-4">
+            <p class="text-sm">{{ discardDescription }}</p>
+            <UAlert
+              v-if="discardError"
+              color="error"
+              icon="i-heroicons-exclamation-triangle"
+              :description="discardError"
+            />
+            <div class="flex justify-end gap-2">
+              <UButton
+                variant="ghost"
+                color="neutral"
+                :disabled="discarding"
+                @click="closeDiscardModal"
+              >
+                Cancel
+              </UButton>
+              <UButton
+                color="error"
+                icon="i-heroicons-arrow-uturn-left"
+                :loading="discarding"
+                @click="confirmDiscard"
+              >
+                Discard
+              </UButton>
+            </div>
+          </div>
         </template>
       </UModal>
 

--- a/web/app/utils/vocab-ttl-meta.ts
+++ b/web/app/utils/vocab-ttl-meta.ts
@@ -1,0 +1,73 @@
+/**
+ * Lightweight metadata extraction from a raw vocabulary TTL file.
+ *
+ * Used by the workspace to list vocabularies that exist as TTL files on a
+ * work branch (develop, edit/*) but are not yet in the generated
+ * /export/system/vocabularies/index.json — the index is only rebuilt when the
+ * deploy branch is reprocessed, so a newly created or newly approved vocab is
+ * otherwise invisible in the workspace until it is published AND deployed.
+ *
+ * Parses with N3 and pulls just enough metadata to render a list entry and
+ * navigate to the scheme page.
+ */
+
+import { Parser } from 'n3'
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
+const SKOS = 'http://www.w3.org/2004/02/skos/core#'
+
+export interface VocabTtlMeta {
+  iri: string
+  prefLabel: string
+  definition?: string
+  conceptCount: number
+}
+
+/**
+ * Extract ConceptScheme IRI, labels and a concept count from raw TTL.
+ * Returns null when the TTL is unparseable or contains no ConceptScheme.
+ * Label/definition prefer @en, falling back to the first value found.
+ */
+export function parseVocabTtlMeta(ttl: string): VocabTtlMeta | null {
+  let quads
+  try {
+    quads = new Parser().parse(ttl)
+  } catch {
+    return null
+  }
+
+  let schemeIri: string | null = null
+  const concepts = new Set<string>()
+  for (const q of quads) {
+    if (q.predicate.value !== RDF_TYPE) continue
+    if (q.object.value === `${SKOS}ConceptScheme`) {
+      if (!schemeIri) schemeIri = q.subject.value
+    } else if (q.object.value === `${SKOS}Concept`) {
+      concepts.add(q.subject.value)
+    }
+  }
+  if (!schemeIri) return null
+
+  let prefLabel = ''
+  let prefLabelEn = ''
+  let definition = ''
+  let definitionEn = ''
+  for (const q of quads) {
+    if (q.subject.value !== schemeIri || q.object.termType !== 'Literal') continue
+    const lang = 'language' in q.object ? (q.object as { language: string }).language : ''
+    if (q.predicate.value === `${SKOS}prefLabel`) {
+      if (lang === 'en' && !prefLabelEn) prefLabelEn = q.object.value
+      if (!prefLabel) prefLabel = q.object.value
+    } else if (q.predicate.value === `${SKOS}definition`) {
+      if (lang === 'en' && !definitionEn) definitionEn = q.object.value
+      if (!definition) definition = q.object.value
+    }
+  }
+
+  return {
+    iri: schemeIri,
+    prefLabel: prefLabelEn || prefLabel,
+    definition: (definitionEn || definition) || undefined,
+    conceptCount: concepts.size,
+  }
+}

--- a/web/tests/unit/promotion.test.ts
+++ b/web/tests/unit/promotion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { buildPRBody } from '~/composables/usePromotion'
+import { buildPRBody, planDiscard } from '~/composables/usePromotion'
 import type { SubjectChange } from '~/composables/useEditMode'
 
 // ---------------------------------------------------------------------------
@@ -50,6 +50,46 @@ describe('buildPRBody', () => {
 
     const body = buildPRBody(changes)
     expect(body).toContain('| Concept C | removed | - |')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// planDiscard (pure function — decides how to unwind a staged vocab change)
+// ---------------------------------------------------------------------------
+
+describe('planDiscard', () => {
+  it('deletes an added vocab from the workspace branch', () => {
+    expect(planDiscard('added', 'headsha', null)).toEqual({ kind: 'delete', sha: 'headsha' })
+  })
+
+  it('is a noop when an added vocab is already gone from the branch', () => {
+    expect(planDiscard('added', null, null)).toEqual({ kind: 'noop' })
+  })
+
+  it('restores base content over a modified vocab (sha = existing head file)', () => {
+    expect(planDiscard('modified', 'headsha', 'YmFzZTY0')).toEqual({
+      kind: 'restore',
+      content: 'YmFzZTY0',
+      sha: 'headsha',
+    })
+  })
+
+  it('recreates a removed vocab from base (no head sha — file is absent)', () => {
+    expect(planDiscard('removed', null, 'YmFzZTY0')).toEqual({
+      kind: 'restore',
+      content: 'YmFzZTY0',
+      sha: undefined,
+    })
+  })
+
+  it('errors when base content is unavailable for a modified/removed vocab', () => {
+    expect(planDiscard('modified', 'headsha', null)).toEqual({ kind: 'error', reason: 'missing-base' })
+    expect(planDiscard('removed', null, null)).toEqual({ kind: 'error', reason: 'missing-base' })
+  })
+
+  it('never plans a base restore for an added vocab (nothing exists on base)', () => {
+    // Even if a caller passed base content by mistake, added → delete
+    expect(planDiscard('added', 'headsha', 'YmFzZTY0')).toEqual({ kind: 'delete', sha: 'headsha' })
   })
 })
 

--- a/web/tests/unit/vocab-ttl-meta.test.ts
+++ b/web/tests/unit/vocab-ttl-meta.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import { parseVocabTtlMeta } from '~/utils/vocab-ttl-meta'
+import { scaffoldSchemeTTL } from '~/composables/useVocabCreate'
+
+describe('parseVocabTtlMeta', () => {
+  it('parses a freshly scaffolded ConceptScheme (the create-vocab shape)', () => {
+    const ttl = scaffoldSchemeTTL(
+      'https://pid.geoscience.gov.au/def/voc/ga/TestVocab',
+      'Test Vocab',
+      'A test vocabulary.',
+    )
+    const meta = parseVocabTtlMeta(ttl)
+    expect(meta).not.toBeNull()
+    expect(meta!.iri).toBe('https://pid.geoscience.gov.au/def/voc/ga/TestVocab')
+    expect(meta!.prefLabel).toBe('Test Vocab')
+    expect(meta!.definition).toBe('A test vocabulary.')
+    expect(meta!.conceptCount).toBe(0)
+  })
+
+  it('parses a GA-style vocab with concepts and counts them', () => {
+    const ttl = `PREFIX : <https://pid.geoscience.gov.au/def/voc/ga/MyVocab/>
+PREFIX cs: <https://pid.geoscience.gov.au/def/voc/ga/MyVocab>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+cs:
+    a skos:ConceptScheme ;
+    skos:prefLabel "My Vocab"@en ;
+    skos:definition "Vocab with concepts."@en ;
+    skos:hasTopConcept :first ;
+.
+
+:first
+    a skos:Concept ;
+    skos:prefLabel "First"@en ;
+    skos:topConceptOf cs: ;
+.
+
+:second
+    a skos:Concept ;
+    skos:prefLabel "Second"@en ;
+    skos:broader :first ;
+    skos:inScheme cs: ;
+.
+`
+    const meta = parseVocabTtlMeta(ttl)
+    expect(meta).not.toBeNull()
+    expect(meta!.iri).toBe('https://pid.geoscience.gov.au/def/voc/ga/MyVocab')
+    expect(meta!.prefLabel).toBe('My Vocab')
+    expect(meta!.conceptCount).toBe(2)
+  })
+
+  it('prefers the @en label when multiple languages exist', () => {
+    const ttl = `PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+<http://example.org/v> a skos:ConceptScheme ;
+  skos:prefLabel "Vokabular"@de, "Vocabulary"@en .
+`
+    const meta = parseVocabTtlMeta(ttl)
+    expect(meta!.prefLabel).toBe('Vocabulary')
+  })
+
+  it('does not double-count a concept typed twice', () => {
+    const ttl = `PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+<http://example.org/v> a skos:ConceptScheme ; skos:prefLabel "V"@en .
+<http://example.org/v/a> a skos:Concept ; skos:prefLabel "A"@en .
+<http://example.org/v/a> a skos:Concept .
+`
+    expect(parseVocabTtlMeta(ttl)!.conceptCount).toBe(1)
+  })
+
+  it('returns null for TTL without a ConceptScheme', () => {
+    const ttl = `PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+<http://example.org/c> a skos:Concept ; skos:prefLabel "Orphan"@en .
+`
+    expect(parseVocabTtlMeta(ttl)).toBeNull()
+  })
+
+  it('returns null for unparseable TTL', () => {
+    expect(parseVocabTtlMeta('this is }{ not turtle <<')).toBeNull()
+  })
+
+  it('handles a label-less scheme (empty prefLabel, caller falls back to slug)', () => {
+    const ttl = `PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+<http://example.org/v> a skos:ConceptScheme .
+`
+    const meta = parseVocabTtlMeta(ttl)
+    expect(meta).not.toBeNull()
+    expect(meta!.prefLabel).toBe('')
+    expect(meta!.definition).toBeUndefined()
+  })
+})

--- a/web/tests/unit/workspace-vocabs.test.ts
+++ b/web/tests/unit/workspace-vocabs.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { planVocabMerge } from '~/composables/useWorkspaceVocabs'
+import type { VocabMetadata } from '~/composables/useVocabData'
+
+const vocab = (slug: string): VocabMetadata => ({
+  iri: `https://example.org/${slug}`,
+  slug,
+  prefLabel: slug,
+  conceptCount: 1,
+})
+
+describe('planVocabMerge', () => {
+  it('keeps index vocabs whose TTL is on the branch', () => {
+    const { published, needStubs, dropped } = planVocabMerge(
+      [vocab('A'), vocab('B')],
+      ['A', 'B'],
+    )
+    expect(published.map(v => v.slug)).toEqual(['A', 'B'])
+    expect(needStubs).toEqual([])
+    expect(dropped).toEqual([])
+  })
+
+  it('flags branch-only vocabs as needing stubs (new vocab awaiting deploy)', () => {
+    const { published, needStubs } = planVocabMerge(
+      [vocab('A')],
+      ['A', 'TESTVOCAB', 'Newvocab'],
+    )
+    expect(published.map(v => v.slug)).toEqual(['A'])
+    expect(needStubs).toEqual(['TESTVOCAB', 'Newvocab'])
+  })
+
+  it('drops index vocabs removed on the branch (removed in staging)', () => {
+    const { published, dropped } = planVocabMerge(
+      [vocab('A'), vocab('Gone')],
+      ['A'],
+    )
+    expect(published.map(v => v.slug)).toEqual(['A'])
+    expect(dropped).toEqual(['Gone'])
+  })
+
+  it('handles an empty index (fresh site) — everything is a stub', () => {
+    const { published, needStubs, dropped } = planVocabMerge([], ['A', 'B'])
+    expect(published).toEqual([])
+    expect(needStubs).toEqual(['A', 'B'])
+    expect(dropped).toEqual([])
+  })
+
+  it('handles an empty branch — everything is dropped', () => {
+    const { published, needStubs, dropped } = planVocabMerge([vocab('A')], [])
+    expect(published).toEqual([])
+    expect(needStubs).toEqual([])
+    expect(dropped).toEqual(['A'])
+  })
+})


### PR DESCRIPTION
## Problem

The workspace vocabulary list is built solely from the generated `/export/system/vocabularies/index.json`, which is only rebuilt when the deploy branch is reprocessed. Three failure modes observed on ga-vocabs-editor:

1. A newly created vocab (on an edit branch, or approved into the workspace branch) is **invisible in the vocabularies list** until it is published *and* deployed.
2. The staged-changes summary diffs raw branch TTLs while navigation resolves via the index — a vocab in one but not the other becomes a **ghost entry that silently does nothing when clicked**.
3. Once a new vocab's edit branch is merged away, there is **no way to unwind** the staged change (e.g. after rejecting the publish PR).

## Changes

- **useWorkspaceVocabs** (new): merges the index with vocab TTLs on the workspace branch + this workspace's edit branches. Branch-only vocabs get stub metadata parsed from the TTL (new `vocab-ttl-meta` util, n3), are injected via `injectVocab` so `/scheme` resolves them, and are badged **new**. Index entries whose TTL is gone from the branch are dropped.
- **usePromotion.discardVocabChange** (+ pure `planDiscard`): *added* → delete the TTL from the workspace branch and drop its edit branch; *modified*/*removed* → restore the publish-target content.
- **workspace.vue**: changed-vocab rows navigate with explicit fallbacks (removed → explains discard restores it; missing → error) instead of silently no-opping; per-row discard button with confirm modal.

## Tests

- `vocab-ttl-meta.test.ts`: scaffold + GA-style parsing, @en preference, dedup concept count, unparseable/label-less edge cases
- `workspace-vocabs.test.ts`: `planVocabMerge` (publish/stub/drop)
- `promotion.test.ts`: `planDiscard` all statuses + edge cases

470/470 unit tests pass. Typecheck: no new errors beyond the pre-existing `n3` no-declarations class (the new util imports n3 like the 12 existing importers).