### PR TITLE
feat: delete vocabulary from the editor; survive deletion in incremental processing

### DIFF
--- a/.github/workflows/site-process-data.yml
+++ b/.github/workflows/site-process-data.yml
@@ -83,9 +83,19 @@ jobs:
 
           echo "${{ steps.changed.outputs.files }}" | while IFS= read -r file; do
             [ -z "$file" ] && continue
-            echo "Processing: $file"
+            SLUG=$(basename "$file" .ttl)
 
-            ARGS="--source $file --type vocab --outDir public/export/vocabs/$(basename "$file" .ttl)"
+            # A deleted vocab still appears in the diff — remove its exports
+            # instead of processing (process-vocab.js would crash on ENOENT).
+            # The index/search regeneration below drops it from the listings.
+            if [ ! -f "$file" ]; then
+              echo "Deleted: $file — removing exports for $SLUG"
+              rm -rf "public/export/vocabs/$SLUG"
+              continue
+            fi
+
+            echo "Processing: $file"
+            ARGS="--source $file --type vocab --outDir public/export/vocabs/$SLUG"
             [ -f "${{ inputs.config-dir }}/profiles.ttl" ] && ARGS="$ARGS --profiles ${{ inputs.config-dir }}/profiles.ttl"
             [ -d "${{ inputs.background-dir }}" ] && ARGS="$ARGS --backgroundDir ${{ inputs.background-dir }}"
 

--- a/web/app/composables/usePromotion.ts
+++ b/web/app/composables/usePromotion.ts
@@ -618,6 +618,53 @@ export function usePromotion(
     }
   }
 
+  /**
+   * Delete a vocabulary from the workspace branch.
+   *
+   * A published vocab (present on the publish target) becomes a staged
+   * "removed" change — visible on the workspace page, restorable via
+   * discard, and only final once submitted for publishing. An unpublished
+   * vocab is removed outright. Any leftover edit branch is dropped so stale
+   * content can't resurrect the vocab.
+   */
+  async function deleteVocabulary(slug: string): Promise<boolean> {
+    const ws = workspace.activeWorkspace.value
+    if (!ws || !owner || !repo || !token.value) {
+      error.value = 'Not authenticated'
+      return false
+    }
+    error.value = null
+
+    const { githubVocabPath } = useRuntimeConfig().public
+    const vocabPrefix = ((githubVocabPath as string) || 'data/vocabs').replace(/^\/+|\/+$/g, '')
+    const path = `${vocabPrefix}/${slug}.ttl`
+    const contentsUrl = (ref?: string) =>
+      `https://api.github.com/repos/${owner}/${repo}/contents/${path}${ref ? `?ref=${encodeURIComponent(ref)}` : ''}`
+
+    try {
+      const head = await githubFetch<{ sha: string }>(contentsUrl(ws.slug))
+      if (head?.sha) {
+        const res = await githubFetch(contentsUrl(), {
+          method: 'DELETE',
+          body: JSON.stringify({
+            message: `chore: delete vocabulary ${slug}`,
+            sha: head.sha,
+            branch: ws.slug,
+          }),
+        })
+        if (!res) {
+          error.value = lastFetchError.value?.githubMessage ?? `Failed to delete ${slug}`
+          return false
+        }
+      }
+      await workspace.deleteBranch(`edit/${ws.slug}/${slug}`)
+      return true
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : 'Something went wrong. Please try again.'
+      return false
+    }
+  }
+
   /** Generate a default review title for a given layer */
   function generateTitle(layer: 'pending' | 'approved'): string {
     const ws = workspace.activeWorkspace.value
@@ -672,5 +719,6 @@ export function usePromotion(
     getBranches,
     fetchChangedVocabs,
     discardVocabChange,
+    deleteVocabulary,
   }
 }

--- a/web/app/pages/scheme.vue
+++ b/web/app/pages/scheme.vue
@@ -809,6 +809,42 @@ const editErrorModal = ref(false)
 const editErrorMessage = ref('')
 const editErrorPath = ref('')
 
+// --- Delete vocabulary ---
+
+const showDeleteVocabModal = ref(false)
+const deletingVocab = ref(false)
+const deleteVocabError = ref<string | null>(null)
+
+function openDeleteVocabModal() {
+  deleteVocabError.value = null
+  showDeleteVocabModal.value = true
+}
+
+function closeDeleteVocabModal() {
+  showDeleteVocabModal.value = false
+}
+
+async function confirmDeleteVocab() {
+  const slug = vocabSlugForEditor.value
+  if (!promotion || !slug) return
+  deletingVocab.value = true
+  deleteVocabError.value = null
+  const ok = await promotion.deleteVocabulary(slug)
+  deletingVocab.value = false
+  if (!ok) {
+    deleteVocabError.value = promotion.error.value ?? 'Failed to delete the vocabulary'
+    return
+  }
+  showDeleteVocabModal.value = false
+  // Leave edit mode without prompting and clear the vocab selection —
+  // the file this editor session was bound to no longer exists.
+  editMode?.exitEditMode(true)
+  if (workspace.state.value) {
+    workspace.selectWorkspace(workspace.state.value.workspaceSlug)
+  }
+  navigateTo('/workspace')
+}
+
 // Keep the workspace vocab context bound to the vocab currently open in the editor,
 // independent of edit-mode entry. Without this, navigating directly to a vocab while a
 // *different* vocab is left in the workspace state saves to the wrong edit branch (the
@@ -1672,6 +1708,16 @@ function copyIriToClipboard(iri: string) {
             size="xs"
             aria-label="Share or embed this vocabulary"
           />
+          <UButton
+            v-if="isAuthenticated && editView !== 'none' && !historySha && vocabSlugForEditor && promotion"
+            icon="i-heroicons-trash"
+            color="error"
+            variant="ghost"
+            size="xs"
+            aria-label="Delete this vocabulary"
+            title="Delete this vocabulary"
+            @click="openDeleteVocabModal"
+          />
           <!-- History popover moved to EditToolbar -->
           <span v-if="historySha" class="inline-flex items-center gap-1.5 text-xs text-warning-500 dark:text-warning-400 bg-warning-50 dark:bg-warning-950/30 rounded-md px-2 py-0.5">
             <UIcon name="i-heroicons-clock" class="size-3 shrink-0" />
@@ -2378,6 +2424,53 @@ function copyIriToClipboard(iri: string) {
         <template #footer>
           <div class="flex justify-end">
             <UButton label="Close" @click="editErrorModal = false" />
+          </div>
+        </template>
+      </UModal>
+
+      <!-- Delete Vocabulary Modal -->
+      <UModal v-model:open="showDeleteVocabModal">
+        <template #header>
+          <div class="flex items-center gap-2">
+            <UIcon name="i-heroicons-trash" class="size-5 text-error" />
+            <h3 class="font-semibold">Delete vocabulary</h3>
+          </div>
+        </template>
+        <template #body>
+          <div class="space-y-4">
+            <p class="text-sm">
+              This removes <span class="font-medium">"{{ getLabel(displayScheme?.prefLabel) }}"</span>
+              from the {{ workspace.activeWorkspace.value?.label ?? 'current' }} workspace.
+            </p>
+            <p class="text-sm text-muted">
+              A published vocabulary is staged as removed — it stays live until the change is
+              submitted for publishing, and can be restored with Discard on the workspace page.
+              A vocabulary that has never been published is gone entirely.
+            </p>
+            <UAlert
+              v-if="deleteVocabError"
+              color="error"
+              icon="i-heroicons-exclamation-triangle"
+              :description="deleteVocabError"
+            />
+            <div class="flex justify-end gap-2">
+              <UButton
+                variant="ghost"
+                color="neutral"
+                :disabled="deletingVocab"
+                @click="closeDeleteVocabModal"
+              >
+                Cancel
+              </UButton>
+              <UButton
+                color="error"
+                icon="i-heroicons-trash"
+                :loading="deletingVocab"
+                @click="confirmDeleteVocab"
+              >
+                Delete
+              </UButton>
+            </div>
           </div>
         </template>
       </UModal>

--- a/web/app/pages/workspace.vue
+++ b/web/app/pages/workspace.vue
@@ -131,6 +131,14 @@ const vocabIriMap = computed(() => {
   return map
 })
 
+// Changed rows with display labels. fetchChangedVocabs only knows the
+// published index, so an unpublished vocab falls back to its slug — the
+// stub-inclusive vocab list has the real label.
+const changedVocabsDisplay = computed(() => {
+  const labels = new Map(vocabs.value.map(v => [v.slug, v.prefLabel]))
+  return changedVocabs.value.map(v => ({ ...v, label: labels.get(v.slug) ?? v.label }))
+})
+
 function navigateToVocab(v: { slug: string; label: string; status: string }) {
   if (v.status === 'removed') {
     selectError.value = `"${v.label}" was removed in staging — use Discard to restore it from the published version.`
@@ -369,7 +377,7 @@ const wsLabel = computed(() =>
 
 /** Map changedVocabs to SubjectChange[] so ReviewModal can display them */
 const promotionChanges = computed<SubjectChange[]>(() =>
-  changedVocabs.value.map(v => ({
+  changedVocabsDisplay.value.map(v => ({
     subjectIri: vocabIriMap.value.get(v.slug) ?? v.slug,
     subjectLabel: v.label,
     type: v.status === 'added' ? 'added' as const : 'modified' as const,
@@ -490,7 +498,7 @@ const workspaceBreadcrumbs = computed(() => {
           <!-- Changed vocabs list -->
           <div v-if="changedVocabs.length > 0" class="ml-5.5 space-y-0.5 mb-4">
             <div
-              v-for="v in changedVocabs"
+              v-for="v in changedVocabsDisplay"
               :key="v.slug"
               class="flex items-center gap-1 -mx-2"
             >


### PR DESCRIPTION
## What

There was no way to delete a vocabulary from the editor, and deleting the TTL by hand crashed the `site-process-data` incremental path (`process-vocab.js` ENOENT on the deleted file), leaving stale exports behind.

## Changes

- **`usePromotion.deleteVocabulary`** — removes the vocab TTL from the workspace branch and drops any leftover edit branch. A **published** vocab becomes a staged *removed* change: visible on the workspace page, restorable via Discard, only final once submitted for publishing. An **unpublished** vocab is gone entirely.
- **scheme.vue** — trash action next to the vocab IRI (authenticated edit mode only) with a confirm modal spelling out both outcomes; on success exits edit mode, clears the vocab selection, and returns to the workspace.
- **site-process-data.yml** — the incremental step now detects deleted TTLs in the diff and removes `public/export/vocabs/<slug>/` instead of crashing; index + search regeneration then drop the vocab from listings. (`git add` already stages the deletions.)
- **workspace.vue** — staged-change rows show the vocab's real label for unpublished vocabs (previously fell back to the slug).

## Verification

- 470/470 unit tests pass; typecheck at the pre-existing 66-error baseline (no new errors)
- Live E2E on ga-vocabs-editor planned post-merge: delete a staged vocab → gone; stage deletion of a published vocab → 'removed' row → discard restores it; publish a deletion → incremental Process Data removes exports without crashing