### PR TITLE
fix: create-vocab modal hung forever after a successful create

### DIFF
--- a/web/app/composables/useVocabCreate.ts
+++ b/web/app/composables/useVocabCreate.ts
@@ -9,7 +9,7 @@
  * Flow:
  *   1. selectVocab(slug) + ensureEditBranch()  → edit/<workspace>/<slug>
  *   2. PUT data/vocabs/<slug>.ttl (file creation) to the edit branch
- *   3. injectVocab() + refreshNuxtData() so useScheme / useShare resolve it
+ *   3. injectVocab() + clearNuxtData() so useScheme / useShare resolve it
  *   4. caller navigates to /scheme?uri=<iri> to add concepts via the normal flow
  */
 
@@ -214,7 +214,13 @@ export function useVocabCreate() {
 
       // 4. Make the new vocab visible to the editor before CI reprocessing.
       injectVocab({ iri, slug, prefLabel: title, definition, conceptCount: 0 })
-      await refreshNuxtData(['schemes', 'vocabMetadata', 'export-vocabs'])
+      // Drop cached asyncData so the scheme page re-runs its fetchers (which
+      // read the injectVocab-patched caches) on mount. This must be
+      // clearNuxtData, not `await refreshNuxtData(...)`: on /workspace none of
+      // these keys have mounted consumers, and refreshNuxtData never resolves
+      // for consumer-less keys — the create hung forever with the vocab
+      // already committed to GitHub and the modal stuck open.
+      clearNuxtData(['schemes', 'vocabMetadata', 'export-vocabs'])
 
       return { ok: true, iri, slug }
     } catch (e: unknown) {

--- a/web/app/composables/useVocabData.ts
+++ b/web/app/composables/useVocabData.ts
@@ -210,7 +210,7 @@ export function clearCaches() {
  * index.json (CI hasn't reprocessed) — is visible to the editor immediately.
  *
  * Idempotent by IRI. After calling this, the caller must
- * `refreshNuxtData(['schemes', 'vocabMetadata', 'export-vocabs'])` so the
+ * `clearNuxtData(['schemes', 'vocabMetadata', 'export-vocabs'])` so the
  * useAsyncData consumers (useScheme, useShare) re-read these caches.
  */
 export function injectVocab(meta: VocabMetadata): void {

--- a/web/tests/e2e/create-vocab.spec.ts
+++ b/web/tests/e2e/create-vocab.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * Create Vocabulary E2E Test
+ *
+ * Verifies the full create flow from the workspace dashboard: open the modal,
+ * fill it in, create, and land in the editor. Regression guard for the
+ * create hang — createVocabulary used to `await refreshNuxtData(...)` on keys
+ * with no mounted consumers, which never resolves, leaving the modal open
+ * forever with the vocab already committed to GitHub.
+ *
+ * All GitHub API calls are mocked. No real branches or commits are made.
+ */
+import { test, expect } from './fixtures'
+import { setupWorkspace } from './fixtures/github-mock'
+
+test.describe('Create vocabulary', () => {
+  test('create from workspace closes the modal and opens the editor', async ({ page, mockGitHubAPI }) => {
+    await setupWorkspace(page, 'staging')
+
+    await page.goto('/workspace')
+    await page.getByRole('button', { name: 'New vocabulary' }).click()
+
+    // Fill the form — identifier and IRI derive from the title
+    await page.getByRole('dialog').locator('input').first().fill('Playwright Created Vocab')
+    await page.getByRole('dialog').locator('textarea').fill('Created by the e2e suite against mocked GitHub.')
+
+    await page.getByRole('dialog').getByRole('button', { name: /Create vocabulary/ }).click()
+
+    // The create must complete: modal gone, editor opened on the new vocab.
+    // (The page content itself comes from the mocked contents API, which
+    // serves the shared fixture TTL for every path — assert on the URL.)
+    await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 15_000 })
+    await expect(page).toHaveURL(/\/scheme\?uri=.*PlaywrightCreatedVocab/, { timeout: 15_000 })
+
+    // The scaffold TTL was committed via the mocked contents API
+    expect(mockGitHubAPI.savedRequests.length).toBeGreaterThan(0)
+    const scaffold = mockGitHubAPI.savedRequests[0]!
+    expect(scaffold.message).toContain('create vocabulary')
+    expect(scaffold.content).toContain('Playwright Created Vocab')
+  })
+})


### PR DESCRIPTION
## Symptom

Creating a vocabulary from /workspace commits the scaffold to GitHub successfully, but the New Vocabulary modal never closes and the editor never opens. Reproduced live in two browsers.

## Root cause

`createVocabulary` awaited `refreshNuxtData(['schemes', 'vocabMetadata', 'export-vocabs'])`. Those keys are registered by `useScheme`/`useConcept` — never mounted on /workspace — and **refreshNuxtData never resolves for consumer-less keys**. Confirmed with live instrumentation: every GitHub call resolved (PUT 201), no rejections, no errors — execution simply never passed the await.

## Fix

`clearNuxtData` instead: synchronous (cannot hang), and the scheme page re-runs its fetchers on mount, which read the `injectVocab`-patched caches — same intent, no await on an unresolvable promise.

## Tests

New `create-vocab.spec.ts` e2e (flow was previously uncovered): modal closes, URL reaches `/scheme?uri=…`, scaffold PUT captured. 470/470 unit tests pass.