### PR TITLE
fix: reconcile publish-target content after merge — deletions silently no-opped

### DIFF
--- a/web/app/composables/usePromotion.ts
+++ b/web/app/composables/usePromotion.ts
@@ -665,6 +665,71 @@ export function usePromotion(
     }
   }
 
+  /**
+   * Force the publish target's vocab content to match the workspace branch
+   * after a publish merge.
+   *
+   * Squash-merging develop → master applies develop's commits since the
+   * merge base, not the content difference. Because master accumulates its
+   * own squash + bot-export commits, the base goes stale: a vocab added and
+   * then deleted on develop nets to zero and its deletion silently never
+   * reaches master, even though the PR merges "successfully". Reconcile by
+   * blob-diffing (same content comparison as fetchChangedVocabs) and applying
+   * any residue as explicit commits on the publish target — exactly the
+   * change set the reviewer approved.
+   */
+  async function reconcilePublish(): Promise<{ applied: number; failed: number }> {
+    const ws = workspace.activeWorkspace.value
+    if (!ws || !owner || !repo || !token.value) return { applied: 0, failed: 0 }
+
+    const residual = await fetchChangedVocabs()
+    if (!residual.length) return { applied: 0, failed: 0 }
+
+    const { githubVocabPath } = useRuntimeConfig().public
+    const vocabPrefix = ((githubVocabPath as string) || 'data/vocabs').replace(/^\/+|\/+$/g, '')
+    const urlFor = (slug: string, ref?: string) =>
+      `https://api.github.com/repos/${owner}/${repo}/contents/${vocabPrefix}/${slug}.ttl${ref ? `?ref=${encodeURIComponent(ref)}` : ''}`
+
+    let applied = 0
+    let failed = 0
+    for (const v of residual) {
+      if (v.status === 'removed') {
+        // On the publish target but gone from the workspace branch → delete
+        const target = await githubFetch<{ sha: string }>(urlFor(v.slug, ws.refreshFrom))
+        if (!target?.sha) { applied++; continue }
+        const res = await githubFetch(urlFor(v.slug), {
+          method: 'DELETE',
+          body: JSON.stringify({
+            message: `chore: publish deletion of ${v.slug} (reconcile ${ws.slug} → ${ws.refreshFrom})`,
+            sha: target.sha,
+            branch: ws.refreshFrom,
+          }),
+        })
+        res ? applied++ : failed++
+      } else {
+        // Added/modified on the workspace branch → copy its content across.
+        // Contents API returns base64, which PUT accepts as-is.
+        const src = await githubFetch<{ content?: string }>(urlFor(v.slug, ws.slug))
+        if (!src?.content) { failed++; continue }
+        const target = await githubFetch<{ sha: string }>(urlFor(v.slug, ws.refreshFrom))
+        const res = await githubFetch(urlFor(v.slug), {
+          method: 'PUT',
+          body: JSON.stringify({
+            message: `chore: publish ${v.slug} (reconcile ${ws.slug} → ${ws.refreshFrom})`,
+            content: src.content.replace(/\s/g, ''),
+            branch: ws.refreshFrom,
+            ...(target?.sha ? { sha: target.sha } : {}),
+          }),
+        })
+        res ? applied++ : failed++
+      }
+    }
+    if (failed > 0) {
+      error.value = `Publish reconcile could not apply ${failed} change${failed === 1 ? '' : 's'} — check the repository state`
+    }
+    return { applied, failed }
+  }
+
   /** Generate a default review title for a given layer */
   function generateTitle(layer: 'pending' | 'approved'): string {
     const ws = workspace.activeWorkspace.value
@@ -720,5 +785,6 @@ export function usePromotion(
     fetchChangedVocabs,
     discardVocabChange,
     deleteVocabulary,
+    reconcilePublish,
   }
 }

--- a/web/app/pages/scheme.vue
+++ b/web/app/pages/scheme.vue
@@ -325,6 +325,13 @@ async function handleMergePR() {
       }
     }
 
+    // Layer 3: the squash merge applies commit history, not content
+    // difference — with a stale merge base a deletion can silently no-op.
+    // Reconcile the publish target to match the workspace branch content.
+    if (promotionLayer.value === 'approved') {
+      await promotion.reconcilePublish()
+    }
+
     // Refresh layer diffs
     layerStatus?.refresh()
   } else {

--- a/web/app/pages/workspace.vue
+++ b/web/app/pages/workspace.vue
@@ -317,6 +317,12 @@ async function handleMergePR() {
     // branch entirely and broke the workspace until it was recreated. Ephemeral
     // edit-branch cleanup happens in the Layer 2 flow (scheme.vue), guarded to
     // promotionLayer === 'pending'.
+
+    // The squash merge applies commit history, not content difference — with a
+    // stale merge base a deletion can silently no-op. Reconcile the publish
+    // target to match the workspace branch content.
+    await promotion.reconcilePublish()
+
     await workspace.fetchBranches()
     changedVocabs.value = await promotion.fetchChangedVocabs()
   } else {


### PR DESCRIPTION
## Bug (caught by live E2E)

Publishing a vocab **deletion** silently no-ops. Squash-merging `develop → master` applies develop's *commit history since the merge base*, not the *content difference* — and master accumulates its own squash + bot-export commits, so the base is stale. A vocab added and then deleted on develop nets to zero: the publish PR merges "successfully" with an **empty diff**, the UI says published, and master still serves the vocab. Observed live on ga-vocabs-editor publish PR #122 (empty squash commit `f4cc27e`).

Same diverged-history trap as the changed-in-staging false positives fixed in #33, but on the publish path.

## Fix

`usePromotion.reconcilePublish()`: after a successful Layer-3 merge, blob-diff the workspace branch against the publish target (the same content comparison the staging summary and review modal already use) and apply any residue as explicit commits on the target:

- **removed** → delete the TTL on the target
- **added/modified** → copy the workspace branch content across

The target ends up matching exactly the change set the reviewer approved, regardless of merge-base drift. Wired into both publish call sites (workspace.vue + scheme.vue).

## Verification

470/470 unit tests pass; typecheck at the 66-error pre-existing baseline. Live verification planned post-merge: the stranded `E2EPublishDelete` vocab on master (the observed failure) publishes its deletion through the fixed flow, which also exercises the Process Data incremental-deletion path from #39.